### PR TITLE
base: Set SSL_CERT_FILE so openssl can find root certificates

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -66,7 +66,13 @@ docker_build(
         packages["netbase"],
         packages["tzdata"],
     ],
-    env = {"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+    env = {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        # allows openssl to find the certificates by default
+        # TODO: We should run update-ca-certifaces, but that requires "openssl rehash"
+        # which would probably need to be run inside the container
+        "SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt",
+    },
     tars = [
         ":passwd",
         ":group_tar",

--- a/base/testdata/certs.yaml
+++ b/base/testdata/certs.yaml
@@ -1,6 +1,11 @@
 schemaVersion: "1.0.0"
 commandTests:
-# Basic FS sanity checks.
+# Check that Go programs can read the certificates
 - name: certs
   command: ["/check_certs"]
   exitCode: 0
+# Check that libssl finds the certificates
+- name: openssl verify google
+  command: ["openssl", "s_client", "-strict", "-verify_return_error", "-connect", "www.google.com:443"]
+  exitCode: 0
+  expectedOutput: ["Verification: OK"]


### PR DESCRIPTION
Fixes problems verifying TLS root certificates with Python and anything
else that uses libssl. Fixes issue #155.

libssl1.1 normally searches for certificates by reading a file with a hash
of the certificate in /usr/lib/ssl/certs (e.g. a7060e1bd.0). On Debian,
these links are created by running update-ca-certificates, which runs
openssl rehash. Unfortunately, we can't easily create those links since we
would need to execute a binary linked against Debian's openssl.

As an alternative, set the SSL_CERT_FILE environment variable to
/etc/ssl/certs/ca-certificates.crt which is created by //base:cacerts.
This causes libssl to parse all the root certificates, instead of only
reading the certificate it needs, but it does work.