### PR TITLE
package_manager: update par binary source

### DIFF
--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -3,7 +3,7 @@ load(":dpkg.bzl", "dpkg_list", "dpkg_src")
 def package_manager_repositories():
   native.http_file(
       name = "dpkg_parser",
-      url = ('https://storage.googleapis.com/distroless/package_manager_tools/872f43c0f9b0f3d0d0c4d832edc59a1e4bd63e99/dpkg_parser.par'),
+      url = ('https://storage.googleapis.com/distroless/package_manager_tools/ac8068579db811014780cb80105fc999fc25a730/dpkg_parser.par'),
       executable = True,
-      sha256 = "ec12a77e02b1358434e15e1ce68b08501675350858a8e79599fb9e1064b051c0",
+      sha256 = "08b965c60bef53ca58d26a9c35982137abc7f780a3d35d9bc5bedafea6bb8d9f",
   )


### PR DESCRIPTION
This brings in the changes from https://github.com/GoogleContainerTools/distroless/pull/204 to be used at runtime.