### PR TITLE
Upgrade rules_docker to latest revision

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,7 +182,7 @@ http_file(
 # Docker rules.
 git_repository(
     name = "io_bazel_rules_docker",
-    commit = "74441f0d7000dde42ce02c30ce2d1bf6c0c1eebc",
+    commit = "7401cb256222615c497c0dee5a4de5724a4f4cc7",
     remote = "https://github.com/bazelbuild/rules_docker.git",
 )
 
@@ -226,9 +226,3 @@ load(
 )
 
 _go_image_repos()
-
-git_repository(
-    name = "runtimes_common",
-    remote = "https://github.com/GoogleCloudPlatform/runtimes-common.git",
-    tag = "v0.1.0",
-)

--- a/base/BUILD
+++ b/base/BUILD
@@ -4,7 +4,7 @@ load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_tar")
 load("@io_bazel_rules_docker//contrib:group.bzl", "group_entry", "group_file")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 # Create /etc/passwd with the root user
@@ -93,15 +93,15 @@ docker_build(
     tars = ["//experimental/busybox:busybox.tar"],
 )
 
-structure_test(
+container_test(
     name = "debug_test",
-    config = "testdata/debug.yaml",
+    configs = ["testdata/debug.yaml"],
     image = ":debug",
 )
 
-structure_test(
+container_test(
     name = "base_test",
-    config = "testdata/base.yaml",
+    configs = ["testdata/base.yaml"],
     image = ":base",
 )
 
@@ -118,8 +118,8 @@ docker_build(
     visibility = ["//visibility:private"],
 )
 
-structure_test(
+container_test(
     name = "certs_test",
-    config = "testdata/certs.yaml",
+    configs = ["testdata/certs.yaml"],
     image = ":check_certs_image",
 )

--- a/examples/dotnet/BUILD
+++ b/examples/dotnet/BUILD
@@ -13,11 +13,11 @@ docker_build(
     files = [":bin"],
 )
 
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
-structure_test(
+container_test(
     name = "hello_test",
     size = "small",
-    config = "testdata/hello.yaml",
+    configs = ["testdata/hello.yaml"],
     image = ":hello",
 )

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -9,11 +9,11 @@ java_image(
     main_class = "examples.HelloJava",
 )
 
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
-structure_test(
+container_test(
     name = "hello_test",
     size = "small",
-    config = "testdata/hello.yaml",
+    configs = ["testdata/hello.yaml"],
     image = ":hello",
 )

--- a/examples/nodejs/BUILD
+++ b/examples/nodejs/BUILD
@@ -19,10 +19,10 @@ docker_build(
     ports = ["8000"],
 )
 
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
-structure_test(
+container_test(
     name = "hello_test",
-    config = "testdata/hello.yaml",
+    configs = ["testdata/hello.yaml"],
     image = ":hello",
 )

--- a/examples/nonroot/BUILD
+++ b/examples/nonroot/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 # Create a passwd file with a nonroot user and uid.
@@ -51,9 +51,9 @@ docker_build(
 )
 
 # Test to verify this works :)
-structure_test(
+container_test(
     name = "check_user_test",
-    config = "testdata/user.yaml",
+    configs = ["testdata/user.yaml"],
     image = ":check_user_image",
     visibility = ["//visibility:private"],
 )

--- a/experimental/busybox/BUILD
+++ b/experimental/busybox/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//base:__subpackages__"])
 
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load(":commands.bzl", "BUSYBOX_COMMANDS")
 
 # For convenience, rename busybox-x86_64 to busybox.

--- a/experimental/python2.7/BUILD
+++ b/experimental/python2.7/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@package_bundle//file:packages.bzl", "packages")
 
 [docker_build(
@@ -36,8 +36,8 @@ load("@package_bundle//file:packages.bzl", "packages")
     ":debug",
 ]]
 
-structure_test(
+container_test(
     name = "python27_test",
-    config = "testdata/python27.yaml",
+    configs = ["testdata/python27.yaml"],
     image = ":python27",
 )

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@package_bundle//file:packages.bzl", "packages")
 
 [docker_build(
@@ -37,9 +37,9 @@ load("@package_bundle//file:packages.bzl", "packages")
     ":debug",
 ]]
 
-structure_test(
+container_test(
     name = "python3_test",
-    size = "small",
-    config = "testdata/python3.yaml",
+    size = "medium",
+    configs = ["testdata/python3.yaml"],
     image = ":python3",
 )

--- a/java/BUILD
+++ b/java/BUILD
@@ -31,11 +31,11 @@ cacerts_java(
     ":debug",
 ]]
 
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
-structure_test(
+container_test(
     name = "java8_test",
-    config = "testdata/java.yaml",
+    configs = ["testdata/java.yaml"],
     image = ":java8",
 )
 
@@ -46,8 +46,8 @@ java_image(
     main_class = "testdata.CheckCerts",
 )
 
-structure_test(
+container_test(
     name = "check_certs_test",
-    config = "testdata/java.yaml",
+    configs = ["testdata/java.yaml"],
     image = ":java8",
 )


### PR DESCRIPTION
This PR just upgrades to the latest version of `rules_docker` with the goal of allowing packages from Debian Buster now that https://github.com/bazelbuild/rules_docker/commit/7401cb256222615c497c0dee5a4de5724a4f4cc7 is landed (i.e., unblocking Python 3.6 🙂).

`rules_docker` these days adds `runtimes_common` when `structure_test` is not already defined, now that `structure_test` was moved to its own repo. Unfortunately, the rule in `structure_test` has an invalid label in one of its implicit dependencies (likely from the repo move), so this commit also refactors the users of `structure_test` to now use the still-working `container_test` from `rules_docker` anyway.