### PR TITLE
Same as #210 and #213 broken link

### DIFF
--- a/experimental/nodejs/README.md
+++ b/experimental/nodejs/README.md
@@ -12,4 +12,4 @@ Specifically, the image contains everything in the [base image](../base/README.m
 
 The entrypoint of this image is set to "node", so this image expects users to supply a path to a .js file in the CMD.
 
-See the Node.js [Hello World](../examples/nodejs/) directory for an example.
+See the Node.js [Hello World](../../examples/nodejs/) directory for an example.


### PR DESCRIPTION
The example link in a deep readme is off by one directory.