### PR TITLE
python: Add dash so os.system and Popen.subprocess work

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,6 +83,7 @@ dpkg_list(
         "libpython2.7-minimal",
         "python2.7-minimal",
         "libpython2.7-stdlib",
+        "dash",
 
         #python3
         "libpython3.5-minimal",

--- a/experimental/python2.7/BUILD
+++ b/experimental/python2.7/BUILD
@@ -9,6 +9,7 @@ load("@package_bundle//file:packages.bzl", "packages")
     # Based on //cc so that C extensions work properly.
     base = "//cc" + mode,
     debs = [
+        packages["dash"],
         packages["libbz2-1.0"],
         packages["libexpat1"],
         packages["libdb5.3"],

--- a/experimental/python2.7/testdata/python27.yaml
+++ b/experimental/python2.7/testdata/python27.yaml
@@ -6,6 +6,11 @@ commandTests:
   - name: version
     command: ["/usr/bin/python2.7", "--version"]
     expectedError: ["Python 2.7.13"]
+  # parts of the standard library assume /bin/sh exists via os.system and subprocess.Popen
+  - name: use_shell
+    command: ["/usr/bin/python2.7", "-c",
+      "import subprocess, sys; subprocess.check_call(sys.executable + ' -h', shell=True)"]
+    exitCode: 0
 
   - name: import_BaseHTTPServer
     command: ["/usr/bin/python2.7", "-c", "import BaseHTTPServer"]

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -9,6 +9,7 @@ load("@package_bundle//file:packages.bzl", "packages")
     # Based on //cc so that C extensions work properly.
     base = "//cc" + mode,
     debs = [
+        packages["dash"],
         packages["zlib1g"],
         packages["libbz2-1.0"],
         packages["libncursesw5"],

--- a/experimental/python3/testdata/python3.yaml
+++ b/experimental/python3/testdata/python3.yaml
@@ -12,6 +12,11 @@ commandTests:
   - name: symlink 
     command: ["/usr/bin/python", "--version"]
     expectedOutput: ["Python 3.5.3"]
+  # parts of the standard library assume /bin/sh exists via os.system and subprocess.Popen
+  - name: use_shell
+    command: ["/usr/bin/python3", "-c",
+      "import subprocess, sys; subprocess.check_call(sys.executable + ' -h', shell=True)"]
+    exitCode: 0
 
   - name: import_abc
     command: ["/usr/bin/python3", "-c", "import abc"]


### PR DESCRIPTION
The Python standard library includes os.system and Popen.subprocess which
can both take a string argument, which then executes that string in a
shell. Add dash so /bin/sh exists and the standard library works.

Argubly using /bin/sh in this way is dangerous and deprecated, but parts of
the standard library itself rely on this (e.g. ctypes). I suspect there are
many Python programs "in the wild" that do as well. If the goal of the
default base image for rules_docker and distroless is to reliably run any
Python program, it should support this, since this is part of the standard
library. The additional ~200 kiB seems worth the additional compatibility.

Found while investigating
https://github.com/GoogleContainerTools/distroless/issues/150