### PR TITLE
Remove duplicate listing for gcr.io/distroless/(java|cc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Follow these steps to get started:
     * [gcr.io/distroless/python2.7](experimental/python2.7/README.md)
     * [gcr.io/distroless/python3](experimental/python3/README.md)
     * [gcr.io/distroless/nodejs](experimental/nodejs/README.md)
-    * [gcr.io/distroless/java](java/README.md)
     * [gcr.io/distroless/java/jetty](java/jetty/README.md)
     * [gcr.io/distroless/cc](cc/README.md)
     * [gcr.io/distroless/dotnet](experimental/dotnet/README.md)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Follow these steps to get started:
     * [gcr.io/distroless/python3](experimental/python3/README.md)
     * [gcr.io/distroless/nodejs](experimental/nodejs/README.md)
     * [gcr.io/distroless/java/jetty](java/jetty/README.md)
-    * [gcr.io/distroless/cc](cc/README.md)
     * [gcr.io/distroless/dotnet](experimental/dotnet/README.md)
 * Write a multi-stage docker file.
   Note: This requires Docker 17.05 or higher.


### PR DESCRIPTION
Since they're isted in the first list, I guess it's stable, and shouldn't be in the second list of experimental images.