### PR TITLE
Add awareness of Docker container memory size and urandom

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -18,6 +18,10 @@ cacerts_java(
     ],
     entrypoint = [
         "/usr/bin/java",
+        "-XX:+UnlockExperimentalVMOptions",
+        "-XX:+UseCGroupMemoryLimitForHeap",
+        "-XX:MaxRAMFraction=1",
+        "-Djava.security.egd=file:/dev/./urandom",
         "-jar",
         # We expect users to use:
         # cmd = ["/path/to/deploy.jar", "--option1", ...]


### PR DESCRIPTION
Should the Docker image provide automatic container limits awareness to the Java app?
I think it does not make sense to leave out the JVM options for memory limits since it is an unexpected behaviour.

MaxRAMFraction=1 sets the maximum Heap to around 95% of the Docker container memory. Otherwise, only around half or less of the Docker container memory is set as maximum Heap. Is this safe since there is not much anything else running in a Distroless Docker container?

Is URandom really safe? https://www.2uo.de/myths-about-uandom/
This might be arguable?