### PR TITLE
WORKSPACE: Update libc-bin to latest released version (security)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,7 +85,9 @@ dpkg_list(
         "python2.7-minimal",
         "libpython2.7-stdlib",
         "dash",
-        "libc-bin",
+        # Version required to skip a security fix to the pre-release library
+        # TODO: Remove when there is a security fix or dpkg_list finds the recent version
+        "libc-bin=2.24-11+deb9u3",
 
         #python3
         "libpython3.5-minimal",


### PR DESCRIPTION
Commit b35d94bc3d added libc-bin to the Python image. Since dpkg_parser
does not parse and compare versions, it is getting the most recent
version from debian_security, which is an older pre-release security fix,
rather than the released version. To fix it, ask for the right version.
A similar issue was fixed for libc6 itself in 6f5345dd25.

Updates libc-bin from 2.24-11+deb9u1 to 2.24-11+deb9u3

Found by the Google Cloud container security scanner.