### PR TITLE
Add a distroless "go" base image.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,8 @@ load("@io_bazel_rules_docker//docker:docker.bzl", "docker_bundle")
 docker_bundle(
     name = "all",
     images = {
-        "gcr.io/{PROJECT_ID}/base:latest": "//base",
+        "gcr.io/{PROJECT_ID}/go:latest": "//base:static",
+        "gcr.io/{PROJECT_ID}/base:latest": "//base:base",
         "gcr.io/{PROJECT_ID}/base:debug": "//base:debug",
         "gcr.io/{PROJECT_ID}/cc:latest": "//cc",
         "gcr.io/{PROJECT_ID}/cc:debug": "//cc:debug",

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Follow these steps to get started:
 
 * Pick the right base image for your application stack.
   We publish the following distroless base images on `gcr.io`:
+    * [gcr.io/distroless/static](base/README.md)
     * [gcr.io/distroless/base](base/README.md)
     * [gcr.io/distroless/java](java/README.md)
     * [gcr.io/distroless/cc](cc/README.md)

--- a/base/BUILD
+++ b/base/BUILD
@@ -58,12 +58,9 @@ cacerts(
 # directory with specific permissions.
 
 docker_build(
-    name = "base",
+    name = "static",
     debs = [
         packages["base-files"],
-        packages["libc6"],
-        packages["libssl1.1"],
-        packages["openssl"],
         packages["netbase"],
         packages["tzdata"],
         ":cacerts.deb",
@@ -81,6 +78,16 @@ docker_build(
         ":tmp.tar",
         ":nsswitch.tar",
         "@debian_stretch//file:os_release.tar",
+    ],
+)
+
+docker_build(
+    name = "base",
+    base = ":static",
+    debs = [
+        packages["libc6"],
+        packages["libssl1.1"],
+        packages["openssl"],
     ],
 )
 

--- a/base/README.md
+++ b/base/README.md
@@ -1,17 +1,22 @@
-# Documentation for `gcr.io/distroless/base`
+# Documentation for `gcr.io/distroless/base` and `gcr.io/distroless/static`
 
 ## Image Contents
 
 This image contains a minimal Linux, glibc-based system. It is intended for use directly by "mostly-statically compiled" languages like Go, Rust or D.
 
-The image contains:
+Statically compiled applications (Go) that do not require libc can use the `gcr.io/distroless/static` image, which contains:
+
+* ca-certificates
+* A /etc/passwd entry for a root user
+* A /tmp directory
+* tzdata
+
+Most other applications (and Go apps that require libc/cgo) should start with `gcr.io/distroless/base`, which contains all
+of the packages in `gcr.io/distroless/static`, and 
 
 * glibc
 * libssl
 * openssl
-* ca-certificates
-* A /etc/passwd entry for a root user
-* A /tmp directory
 
 ## Usage
 


### PR DESCRIPTION
This image is like base, but has even fewer dependencies. Notably, the following packages are removed:
- libc
- openssl