### PR TITLE
Upgrade NodeJS to the latest Carbon LTS (v8.15.0)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -171,10 +171,10 @@ http_archive(
 http_archive(
     name = "nodejs",
     build_file = "//experimental/nodejs:BUILD.nodejs",
-    sha256 = "3df19b748ee2b6dfe3a03448ebc6186a3a86aeab557018d77a0f7f3314594ef6",
-    strip_prefix = "node-v8.12.0-linux-x64/",
+    sha256 = "dc004e5c0f39c6534232a73100c194bc1446f25e3a6a39b29e2000bb3d139d52",
+    strip_prefix = "node-v8.15.0-linux-x64/",
     type = "tar.gz",
-    urls = ["https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-x64.tar.gz"],
+    urls = ["https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-x64.tar.gz"],
 )
 
 # dotnet

--- a/examples/nodejs/Dockerfile
+++ b/examples/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.1 AS build-env
+FROM node:8.15.0 AS build-env
 ADD . /app
 WORKDIR /app
 

--- a/experimental/nodejs/README.md
+++ b/experimental/nodejs/README.md
@@ -6,7 +6,7 @@ This image contains a minimal Linux, Node.js-based runtime.
 
 Specifically, the image contains everything in the [base image](../../base/README.md), plus:
 
-* Node.js v8.9.1 and its dependencies.
+* Node.js v8.15.0 and its dependencies.
 
 ## Usage
 


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/

Fixes for the following CVEs are included in this release:

- Node.js: Denial of Service with large HTTP headers (CVE-2018-12121)
- Node.js: Slowloris HTTP Denial of Service (CVE-2018-12122 / Node.js)
- Node.js: Hostname spoofing in URL parser for javascript protocol (CVE-2018-12123)
- Node.js: HTTP request splitting (CVE-2018-12116)
- OpenSSL: Timing vulnerability in DSA signature generation (CVE-2018-0734)
- OpenSSL: Microarchitecture timing vulnerability in ECC scalar multiplication (CVE-2018-5407)
