### PR TITLE
WORKSPACE: Update to latest Debian snapshot

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ dpkg_src(
     arch = "amd64",
     distro = "stretch",
     sha256 = "a0c5a8906ac6ad010535cca152df43411d0e5db1790f6d0e4106bbdf96f3ef0f",
-    snapshot = "20181126T091904Z",
+    snapshot = "20181210T092708Z",
     url = "https://snapshot.debian.org/archive",
 )
 
@@ -44,16 +44,16 @@ dpkg_src(
     name = "debian_stretch_backports",
     arch = "amd64",
     distro = "stretch-backports",
-    sha256 = "4c8515231c78581af0a368db5754f8f6a849e0130e67ae64f839be18333940e0",
-    snapshot = "20181126T091904Z",
+    sha256 = "a0f3402ab589998648fca6c7362b31974d2667d37ed57fe468cfa3cb018db303",
+    snapshot = "20181210T092708Z",
     url = "http://snapshot.debian.org/archive",
 )
 
 dpkg_src(
     name = "debian_stretch_security",
-    package_prefix = "https://snapshot.debian.org/archive/debian-security/20181125T203440Z/",
-    packages_gz_url = "https://snapshot.debian.org/archive/debian-security/20181125T203440Z/dists/stretch/updates/main/binary-amd64/Packages.gz",
-    sha256 = "ab542405693aaf490ef2c2ffa58e3bfc3a14446bbd9010f9b9361127df1cc5d9",
+    package_prefix = "https://snapshot.debian.org/archive/debian-security/20181210T102358Z/",
+    packages_gz_url = "https://snapshot.debian.org/archive/debian-security/20181210T102358Z/dists/stretch/updates/main/binary-amd64/Packages.gz",
+    sha256 = "755ac2ac3f235f3929ad01baf04f596740f038ea1873fe55013bbfe727b4194b",
 )
 
 dpkg_list(


### PR DESCRIPTION
This includes a security fix to OpenSSL released on 2018-11-30:
https://www.debian.org/security/2018/dsa-4348

This is reported as a vulnerability by the Google Cloud container
security scanner.