### PR TITLE
Add option in cacerts rules to include additional ca certs

### DIFF
--- a/cacerts/cacerts.bzl
+++ b/cacerts/cacerts.bzl
@@ -1,11 +1,15 @@
 """A rule to unpack ca certificates from the debian package."""
 
 def _impl(ctx):
-    args = "%s %s %s %s" % (
+    file_inputs = ctx.certs.srcs[:]
+    file_args = ' '.join([str(f.path) for f in file_inputs])
+
+    args = "%s %s %s %s \"%s\"" % (
 	ctx.executable._extract.path,
 	ctx.file.deb.path,
 	ctx.outputs.tar.path,
 	ctx.outputs.deb.path,
+    file_args,
     )
 
     ctx.action(command = args,
@@ -18,6 +22,9 @@ cacerts = rule(
             allow_files = [".deb"],
             single_file = True,
             mandatory = True,
+        ),
+        "certs": attr.label_key_string_dict(
+            allow_files = [".crt"],
         ),
         # Implicit dependencies.
         "_extract": attr.label(

--- a/cacerts/cacerts.bzl
+++ b/cacerts/cacerts.bzl
@@ -23,7 +23,7 @@ cacerts = rule(
             single_file = True,
             mandatory = True,
         ),
-        "certs": attr.label_key_string_dict(
+        "certs": attr.label_keyed_string_dict(
             allow_files = [".crt"],
         ),
         # Implicit dependencies.

--- a/cacerts/cacerts.bzl
+++ b/cacerts/cacerts.bzl
@@ -1,9 +1,8 @@
 """A rule to unpack ca certificates from the debian package."""
 
 def _impl(ctx):
-    file_inputs = ctx.certs.srcs[:]
-    file_args = ' '.join([str(f.path) for f in file_inputs])
-
+    file_args = ' '.join([str(f.path) for f in ctx.files.certs[:]])
+    # file_args = ' '.join([str(_remap(remap_paths, dest_path(f, data_path)) for f in ctx.files.certs[:]])
     args = "%s %s %s %s \"%s\"" % (
 	ctx.executable._extract.path,
 	ctx.file.deb.path,
@@ -23,7 +22,7 @@ cacerts = rule(
             single_file = True,
             mandatory = True,
         ),
-        "certs": attr.label_keyed_string_dict(
+        "certs": attr.label_list(
             allow_files = [".crt"],
         ),
         # Implicit dependencies.

--- a/cacerts/cacerts.bzl
+++ b/cacerts/cacerts.bzl
@@ -2,7 +2,6 @@
 
 def _impl(ctx):
     file_args = ' '.join([str(f.path) for f in ctx.files.certs[:]])
-    # file_args = ' '.join([str(_remap(remap_paths, dest_path(f, data_path)) for f in ctx.files.certs[:]])
     args = "%s %s %s %s \"%s\"" % (
 	ctx.executable._extract.path,
 	ctx.file.deb.path,
@@ -12,7 +11,7 @@ def _impl(ctx):
     )
 
     ctx.action(command = args,
-            inputs = [ctx.executable._extract, ctx.file.deb],
+            inputs = [ctx.executable._extract, ctx.file.deb] + ctx.files.certs,
             outputs = [ctx.outputs.tar, ctx.outputs.deb])
 
 cacerts = rule(

--- a/cacerts/extract.sh
+++ b/cacerts/extract.sh
@@ -25,6 +25,7 @@ set -e
 DEB=$1
 OUT_TAR=$2
 OUT_DEB=$3
+CERTS_FILES=$4
 
 cp "$DEB" "$OUT_DEB"
 
@@ -44,6 +45,10 @@ mkdir -p $(dirname $CERT_FILE)
 
 CERTS=$(find usr/share/ca-certificates -type f | sort)
 for cert in $CERTS; do
+  cat $cert >> $CERT_FILE
+done
+
+for cert in $CERTS_FILES; do
   cat $cert >> $CERT_FILE
 done
 

--- a/cacerts/extract.sh
+++ b/cacerts/extract.sh
@@ -48,6 +48,10 @@ for cert in $CERTS; do
   cat $cert >> $CERT_FILE
 done
 
+echo $DEB
+echo $CERTS_FILES
+echo $(pwd)
+
 for cert in $CERTS_FILES; do
   cat $cert >> $CERT_FILE
 done

--- a/cacerts/extract.sh
+++ b/cacerts/extract.sh
@@ -48,10 +48,6 @@ for cert in $CERTS; do
   cat $cert >> $CERT_FILE
 done
 
-echo $DEB
-echo $CERTS_FILES
-echo $(pwd)
-
 for cert in $CERTS_FILES; do
   cat $cert >> $CERT_FILE
 done


### PR DESCRIPTION
This features allow adding additional ca certificates in the cacerts rule. This is useful when ca certs are needed which are not part of the `ca-certificates` Debian package.