### PR TITLE
Migrate docker rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_bundle")
+load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
 
-docker_bundle(
+container_bundle(
     name = "all",
     images = {
         "gcr.io/{PROJECT_ID}/go:latest": "//base:static",
@@ -23,12 +23,12 @@ docker_bundle(
         "gcr.io/{PROJECT_ID}/dotnet:latest": "//experimental/dotnet",
         "gcr.io/{PROJECT_ID}/dotnet:debug": "//experimental/dotnet:debug",
     },
-    stamp = True,
 )
 
-load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
+load("@io_bazel_rules_docker//contrib:push-all.bzl", "container_push")
 
-docker_push(
+container_push(
     name = "publish",
+    format = "Docker",
     bundle = ":all",
 )

--- a/BUILD
+++ b/BUILD
@@ -29,6 +29,6 @@ load("@io_bazel_rules_docker//contrib:push-all.bzl", "container_push")
 
 container_push(
     name = "publish",
-    format = "Docker",
     bundle = ":all",
+    format = "Docker",
 )

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See here for:
 See here for examples on how to complete some common tasks in your image:
 
 * [Adding and running as a non-root user](examples/nonroot)
-* [Including debian packages](https://github.com/bazelbuild/rules_docker#docker_build-1)
+* [Including debian packages](https://github.com/bazelbuild/rules_docker#container_image-1)
 * [Including CA certificates](cacerts/)
 
 See here for more information on how these images are [built and released](RELEASES.md).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,11 +5,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
     sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
 )
+
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+
 go_rules_dependencies()
+
 go_register_toolchains()
 
 load(
@@ -191,6 +194,7 @@ http_archive(
     strip_prefix = "rules_docker-0.7.0",
     urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
 )
+
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -199,9 +199,10 @@ load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_repositories()
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 # Used to generate java ca certs.
 container_pull(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,25 +1,15 @@
 workspace(name = "distroless")
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-git_repository(
-    name = "subpar",
-    remote = "https://github.com/google/subpar",
-    tag = "1.0.0",
-)
-
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.16.3",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
+    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
 )
-
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
-
 go_rules_dependencies()
-
 go_register_toolchains()
 
 load(
@@ -195,20 +185,20 @@ http_file(
 )
 
 # Docker rules.
-git_repository(
+http_archive(
     name = "io_bazel_rules_docker",
-    commit = "5eb0728594013d746959c4bd21aa4b0c3e3848d8",
-    remote = "https://github.com/bazelbuild/rules_docker.git",
+    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
+    strip_prefix = "rules_docker-0.7.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
 )
-
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 load(
-    "@io_bazel_rules_docker//docker:docker.bzl",
-    "docker_pull",
-    "docker_repositories",
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
 )
 
 # Used to generate java ca certs.
-docker_pull(
+container_pull(
     name = "debian8",
     # From tag: 2017-09-11-115552
     digest = "sha256:6d381d0bf292e31291136cff03b3209eb40ef6342fb790483fa1b9d3af84ae46",
@@ -216,7 +206,7 @@ docker_pull(
     repository = "google-appengine/debian8",
 )
 
-docker_repositories()
+container_repositories()
 
 # Have the py_image dependencies for testing.
 load(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -195,11 +195,13 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
 )
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+
+container_repositories()
 
 # Used to generate java ca certs.
 container_pull(
@@ -209,8 +211,6 @@ container_pull(
     registry = "gcr.io",
     repository = "google-appengine/debian8",
 )
-
-container_repositories()
 
 # Have the py_image dependencies for testing.
 load(

--- a/base/BUILD
+++ b/base/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_tar")
 load("@io_bazel_rules_docker//contrib:group.bzl", "group_entry", "group_file")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 # Create /etc/passwd with the root user
@@ -57,7 +57,7 @@ cacerts(
 # A tar is needed because at the moment there is no way to create a
 # directory with specific permissions.
 
-docker_build(
+container_image(
     name = "static",
     debs = [
         packages["base-files"],
@@ -81,7 +81,7 @@ docker_build(
     ],
 )
 
-docker_build(
+container_image(
     name = "base",
     base = ":static",
     debs = [
@@ -92,7 +92,7 @@ docker_build(
 )
 
 # A debug image with busybox available.
-docker_build(
+container_image(
     name = "debug",
     base = ":base",
     directory = "/",
@@ -119,7 +119,7 @@ go_binary(
     pure = "on",
 )
 
-docker_build(
+container_image(
     name = "check_certs_image",
     base = "//base:base",
     files = [":check_certs"],

--- a/cacerts/java.bzl
+++ b/cacerts/java.bzl
@@ -17,7 +17,7 @@
 def _impl(ctx):
     # Strip off the '.tar'
     image_name = ctx.attr._builder_image.label.name.split('.', 1)[0]
-    # docker_build rules always generate an image named 'bazel/$package:$name'.
+    # container_image rules always generate an image named 'bazel/$package:$name'.
     builder_image_name = "bazel/%s:%s" % (ctx.attr._builder_image.label.package,
                                           image_name)
 

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@package_bundle//file:packages.bzl", "packages")
 
 # An intermediate image for Java and other "mostly statically" compiled languages
-[docker_build(
+[container_image(
     name = "cc" if (not mode) else mode[1:],
     base = "//base" + mode,
     debs = [

--- a/examples/dotnet/BUILD
+++ b/examples/dotnet/BUILD
@@ -1,9 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
-docker_build(
+container_image(
     name = "hello",
     base = "//experimental/dotnet:dotnet",
     cmd = [

--- a/examples/nodejs/BUILD
+++ b/examples/nodejs/BUILD
@@ -1,17 +1,17 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 # These examples are adapted from:
 # https://howtonode.org/hello-node
-docker_build(
+container_image(
     name = "hello",
     base = "//experimental/nodejs:nodejs",
     cmd = ["hello.js"],
     files = [":hello.js"],
 )
 
-docker_build(
+container_image(
     name = "hello_http",
     base = "//experimental/nodejs:nodejs",
     cmd = ["hello_http.js"],

--- a/examples/nonroot/BUILD
+++ b/examples/nonroot/BUILD
@@ -1,8 +1,8 @@
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
-load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 # Create a passwd file with a nonroot user and uid.
@@ -28,7 +28,7 @@ pkg_tar(
 )
 
 # Include it in our image as a tar.
-docker_build(
+container_image(
     name = "passwd_image",
     base = "//base:base",
     tars = [":passwd_tar"],
@@ -43,7 +43,7 @@ go_binary(
     pure = "on",
 )
 
-docker_build(
+container_image(
     name = "check_user_image",
     base = ":passwd_image",
     files = [":user"],

--- a/examples/python2.7/BUILD
+++ b/examples/python2.7/BUILD
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_docker//python:image.bzl", "py_image")
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 py_image(
     name = "hello_py",
@@ -9,7 +9,7 @@ py_image(
 )
 
 # This example runs a python program that walks the filesystem under "/etc" and prints every filename.
-docker_build(
+container_image(
     name = "hello",
     base = ":hello_py",
     cmd = ["/etc"],

--- a/examples/python3/BUILD
+++ b/examples/python3/BUILD
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_docker//python:image.bzl", "py_image")
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 py_image(
     name = "hello_py",
@@ -9,7 +9,7 @@ py_image(
 )
 
 # This example runs a python program that walks the filesystem under "/etc" and prints every filename.
-docker_build(
+container_image(
     name = "hello",
     base = ":hello_py",
     cmd = ["/etc"],

--- a/experimental/dotnet/BUILD
+++ b/experimental/dotnet/BUILD
@@ -1,9 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@package_bundle//file:packages.bzl", "packages")
 
-[docker_build(
+[container_image(
     name = "dotnet" if (not mode) else mode[1:],
     base = "//cc" + mode,
     debs = [

--- a/experimental/dotnet/README.md
+++ b/experimental/dotnet/README.md
@@ -123,7 +123,7 @@ Hello World!
 See the dotnet [Hello World](../../examples/dotnet/) directory for an example and [examples/dotnet/BUILD](../../examples/dotnet/BUILD) using bazel:
 
 ```
-docker_build(
+container_image(
     name = "hello",
     base = "//dotnet:dotnet",
     cmd = [
@@ -214,7 +214,7 @@ Hello World
 which in turn makes the build rule just
 
 ```
-docker_build(
+container_image(
     name = "hello",
     base = "//dotnet:dotnet",
     cmd = [

--- a/experimental/nodejs/BUILD
+++ b/experimental/nodejs/BUILD
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
-[docker_build(
+[container_image(
     name = "nodejs" if (not mode) else mode[1:],
     base = "//cc" + mode,
     entrypoint = ["/nodejs/bin/node"],

--- a/experimental/python2.7/BUILD
+++ b/experimental/python2.7/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@package_bundle//file:packages.bzl", "packages")
 
-[docker_build(
+[container_image(
     name = "python27" if (not mode) else mode[1:],
     # Based on //cc so that C extensions work properly.
     base = "//cc" + mode,

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -1,10 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@package_bundle//file:packages.bzl", "packages")
 
-[docker_build(
+[container_image(
     name = "python3" if (not mode) else mode[1:],
     # Based on //cc so that C extensions work properly.
     base = "//cc" + mode,

--- a/java/BUILD
+++ b/java/BUILD
@@ -1,15 +1,15 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 load("@package_bundle//file:packages.bzl", "packages")
 load("//cacerts:java.bzl", "cacerts_java")
-load("@io_bazel_rules_docker//java:image.bzl", "java_image")
 
 cacerts_java(
     name = "cacerts_java",
 )
 
-[docker_build(
+[container_image(
     name = "java8" if (not mode) else mode[1:],
     base = "//cc" + mode,
     debs = [

--- a/java/jetty/BUILD
+++ b/java/jetty/BUILD
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
-[docker_build(
+[container_image(
     name = "jetty" if (mode == ":java8") else mode[1:],
     base = "//java" + mode,
     cmd = ["/jetty/start.jar"],

--- a/package_manager/README.md
+++ b/package_manager/README.md
@@ -53,7 +53,7 @@ Finally, in a `BUILD` file, you can access the `.deb` files for rules that might
 ```python
 load("@package_bundle//file:packages.bzl", "packages")
 
-docker_build(
+container_image(
     name = "python27",
     base = "//base:base",
     debs = [


### PR DESCRIPTION
Building, testing, and publishing all work. But I admit I've never used these rules before, so I am not strong on pushing this soon. But turns out, this also fixes [the broken `blaze run :publish`](https://github.com/GoogleContainerTools/distroless/pull/263).