### PR TITLE
Maintain package version mapping

### DIFF
--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -82,6 +82,7 @@ def download_dpkg(package_files, packages, workspace_name):
     """
     pkg_vals_to_package_file_and_sha256 = {}
     package_to_rule_map = {}
+    package_to_version_map = {}
     package_file_to_metadata = {}
     for pkg_vals in set(packages.split(",")):
         pkg_split = pkg_vals.split("=")
@@ -102,6 +103,7 @@ def download_dpkg(package_files, packages, workspace_name):
                 pkg = metadata[pkg_name]
                 buf = urllib.request.urlopen(pkg[FILENAME_KEY])
                 package_to_rule_map[pkg_name] = util.package_to_rule(workspace_name, pkg_name)
+                package_to_version_map[pkg_name] = metadata[pkg_name][VERSION_KEY]
                 out_file = os.path.join("file", util.encode_package_name(pkg_name))
                 with io.open(out_file, 'wb') as f:
                     f.write(buf.read())
@@ -124,6 +126,7 @@ def download_dpkg(package_files, packages, workspace_name):
             raise Exception("Package: %s, Version: %s not found in any of the sources" % (pkg_name, pkg_version))
     with open(PACKAGE_MAP_FILE_NAME, 'w') as f:
         f.write("packages = " + json.dumps(package_to_rule_map))
+        f.write("\nversions = " + json.dumps(package_to_version_map))
 
 def download_package_list(mirror_url, distro, arch, snapshot, sha256, packages_gz_url, package_prefix):
     """Downloads a debian package list, expands the relative urls,


### PR DESCRIPTION
#276 and #214 request branding the distroless/java images with metadata about the underlying language runtime version. Unfortunately the package information is not available when building the image: all that is available is the actual `.deb` file.

https://github.com/GoogleContainerTools/distroless/blob/55b0eb29ae8228e59ec14b02ca6b904c20340f06/java/BUILD#L12-L17

Rather than try to extract the `.deb`'s `control.tar.gz` and its `control` file, this PR changes the `package_manager` to also record a package-to-version mapping (`versions`) that is written out with the `@package_bundle//file:packages.bzl`.

The resulting `packages.bzl` file now looks like:
```
packages = {"libgcc1": "@package_bundle//file:bGliZ2NjMQ==.deb", "libgomp1": "@package_bundle//file:bGliZ29tcDE=.deb", ... }
versions = {"libgcc1": "1:6.3.0-18+deb9u1", "libgomp1": "6.3.0-18+deb9u1", ...}
```

With this change, the `java/BUILD` can now pull in the versions information and use `versions[jre_deb]` to annotate the generated images. See [my proposed branch for an example](https://github.com/GoogleContainerTools/distroless/compare/i276-jre).

**Still outstanding:** I'm not sure how the `package_manager_tools` bundle is updated with `package_manager/package_manager.bzl`.