### PR TITLE
Record JRE version details in Java image metadata

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -23,13 +23,13 @@ cacerts_java(
         # We expect users to use:
         # cmd = ["/path/to/deploy.jar", "--option1", ...]
     ],
+    env = {
+        "JAVA_VERSION": jre_ver(versions[jre_deb]),
+    },
     labels = {
         "jdk.version": jre_ver(versions[jre_deb]),
         "jdk.vendor": "openjdk",
         "jdk.source": jre_deb + " " + versions[jre_deb],
-    },
-    env = {
-        "JAVA_VERSION": jre_ver(versions[jre_deb]),
     },
     symlinks = {
         "/usr/bin/java": java_executable_path,

--- a/java/BUILD
+++ b/java/BUILD
@@ -2,8 +2,9 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//java:image.bzl", "java_image")
-load("@package_bundle//file:packages.bzl", "packages")
+load("@package_bundle//file:packages.bzl", "packages", "versions")
 load("//cacerts:java.bzl", "cacerts_java")
+load("//java:jre_ver.bzl", "jre_ver")
 
 cacerts_java(
     name = "cacerts_java",
@@ -22,6 +23,14 @@ cacerts_java(
         # We expect users to use:
         # cmd = ["/path/to/deploy.jar", "--option1", ...]
     ],
+    labels = {
+        "jdk.version": jre_ver(versions[jre_deb]),
+        "jdk.vendor": "openjdk",
+        "jdk.source": jre_deb + " " + versions[jre_deb],
+    },
+    env = {
+        "JAVA_VERSION": jre_ver(versions[jre_deb]),
+    },
     symlinks = {
         "/usr/bin/java": java_executable_path,
     },

--- a/java/BUILD
+++ b/java/BUILD
@@ -26,11 +26,6 @@ cacerts_java(
     env = {
         "JAVA_VERSION": jre_ver(versions[jre_deb]),
     },
-    labels = {
-        "jdk.version": jre_ver(versions[jre_deb]),
-        "jdk.vendor": "openjdk",
-        "jdk.source": jre_deb + " " + versions[jre_deb],
-    },
     symlinks = {
         "/usr/bin/java": java_executable_path,
     },

--- a/java/jre_ver.bzl
+++ b/java/jre_ver.bzl
@@ -1,9 +1,9 @@
 def jre_ver(version):
-  """Extract JRE version from an OpenJDK debian package.
-    debian packages have versions in the form:
+  """Extract JRE version from a Debian openjdk package.
+    Debian packages versions are of the form:
        openjdk-8-jre*: 8u171-b11-1~deb9u1
        openjdk-11-jre*: 11.0.1+13-2~bpo9+1
   """
-  if version.startswith("8u"): return version.split("-",2)[0]
-  if version.startswith("11."): return version.split("+",2)[0]
-  return "unknown: " + version
+  if version.startswith("8u"): return version.split("-")[0]
+  if version.startswith("11."): return version.split("+")[0]
+  fail("unrecognized openjdk package version: " + version)

--- a/java/jre_ver.bzl
+++ b/java/jre_ver.bzl
@@ -1,0 +1,9 @@
+def jre_ver(version):
+  """Extract JRE version from an OpenJDK debian package.
+    debian packages have versions in the form:
+       openjdk-8-jre*: 8u171-b11-1~deb9u1
+       openjdk-11-jre*: 11.0.1+13-2~bpo9+1
+  """
+  if version.startswith("8u"): return version.split("-",2)[0]
+  if version.startswith("11."): return version.split("+",2)[0]
+  return "unknown: " + version

--- a/java/testdata/java11.yaml
+++ b/java/testdata/java11.yaml
@@ -22,4 +22,3 @@ metadataTest:
   env:
     - key: 'JAVA_VERSION'
       value: '11.0.1'
-

--- a/java/testdata/java11.yaml
+++ b/java/testdata/java11.yaml
@@ -19,15 +19,6 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  labels:
-    - key: 'jdk.vendor'
-      value: 'openjdk'
-    - key: 'jdk.version'
-      value: '11.0.1'
-    # isRegex requires container-structure-test v1.7.0
-    #- key: 'jdk.source'
-    #  value: 'openjdk-11-jre-headless 11.0.1\+*'
-    #  isRegex: true
   env:
     - key: 'JAVA_VERSION'
       value: '11.0.1'

--- a/java/testdata/java11.yaml
+++ b/java/testdata/java11.yaml
@@ -1,10 +1,12 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 commandTests:
   - name: java
-    command: ["/usr/lib/jvm/java-11-openjdk-amd64/bin/java", "-version"]
+    command: "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "11\.*']
   - name: java-symlink
-    command: ["/usr/bin/java", "-version"]
+    command: "/usr/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "11\.*']
 fileExistenceTests:
   - name: certs
@@ -16,3 +18,17 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+metadataTest:
+  labels:
+    - key: 'jdk.vendor'
+      value: 'openjdk'
+    - key: 'jdk.version'
+      value: '11.0.1'
+    # isRegex requires container-structure-test v1.7.0
+    #- key: 'jdk.source'
+    #  value: 'openjdk-11-jre-headless 11.0.1\+*'
+    #  isRegex: true
+  env:
+    - key: 'JAVA_VERSION'
+      value: '11.0.1'
+

--- a/java/testdata/java11_debug.yaml
+++ b/java/testdata/java11_debug.yaml
@@ -22,4 +22,3 @@ metadataTest:
   env:
     - key: 'JAVA_VERSION'
       value: '11.0.1'
-

--- a/java/testdata/java11_debug.yaml
+++ b/java/testdata/java11_debug.yaml
@@ -19,15 +19,6 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  labels:
-    - key: 'jdk.vendor'
-      value: 'openjdk'
-    - key: 'jdk.version'
-      value: '11.0.1'
-    # isRegex requires container-structure-test v1.7.0
-    #- key: 'jdk.source'
-    #  value: 'openjdk-11-jre-headless 11.0.1\+*'
-    #  isRegex: true
   env:
     - key: 'JAVA_VERSION'
       value: '11.0.1'

--- a/java/testdata/java11_debug.yaml
+++ b/java/testdata/java11_debug.yaml
@@ -1,10 +1,12 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 commandTests:
   - name: java
-    command: ["/usr/lib/jvm/java-11-openjdk-amd64/bin/java", "-version"]
+    command: "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "11\.*']
   - name: java-symlink
-    command: ["/usr/bin/java", "-version"]
+    command: "/usr/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "11\.*']
 fileExistenceTests:
   - name: certs
@@ -16,3 +18,17 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+metadataTest:
+  labels:
+    - key: 'jdk.vendor'
+      value: 'openjdk'
+    - key: 'jdk.version'
+      value: '11.0.1'
+    # isRegex requires container-structure-test v1.7.0
+    #- key: 'jdk.source'
+    #  value: 'openjdk-11-jre-headless 11.0.1\+*'
+    #  isRegex: true
+  env:
+    - key: 'JAVA_VERSION'
+      value: '11.0.1'
+

--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -22,4 +22,3 @@ metadataTest:
   env:
     - key: 'JAVA_VERSION'
       value: '8u181'
-

--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -1,10 +1,12 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 commandTests:
   - name: java
-    command: ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-version"]
+    command: "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
   - name: java-symlink
-    command: ["/usr/bin/java", "-version"]
+    command: "/usr/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
 fileExistenceTests:
   - name: certs
@@ -16,3 +18,17 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+metadataTest:
+  labels:
+    - key: 'jdk.vendor'
+      value: 'openjdk'
+    - key: 'jdk.version'
+      value: '8u181'
+    # isRegex requires container-structure-test v1.7.0
+    #- key: 'jdk.source'
+    #  value: 'openjdk-8-jre-headless 8u181-*'
+    #  isRegex: true
+  env:
+    - key: 'JAVA_VERSION'
+      value: '8u181'
+

--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -19,15 +19,6 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  labels:
-    - key: 'jdk.vendor'
-      value: 'openjdk'
-    - key: 'jdk.version'
-      value: '8u181'
-    # isRegex requires container-structure-test v1.7.0
-    #- key: 'jdk.source'
-    #  value: 'openjdk-8-jre-headless 8u181-*'
-    #  isRegex: true
   env:
     - key: 'JAVA_VERSION'
       value: '8u181'

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -22,4 +22,3 @@ metadataTest:
   env:
     - key: 'JAVA_VERSION'
       value: '8u181'
-

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -1,10 +1,12 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 commandTests:
   - name: java
-    command: ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-version"]
+    command: "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
   - name: java-symlink
-    command: ["/usr/bin/java", "-version"]
+    command: "/usr/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
 fileExistenceTests:
   - name: certs
@@ -16,3 +18,17 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+metadataTest:
+  labels:
+    - key: 'jdk.vendor'
+      value: 'openjdk'
+    - key: 'jdk.version'
+      value: '8u181'
+    # isRegex requires container-structure-test v1.7.0
+    #- key: 'jdk.source'
+    #  value: 'openjdk-8-jre-headless 8u181-*'
+    #  isRegex: true
+  env:
+    - key: 'JAVA_VERSION'
+      value: '8u181'
+

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -19,15 +19,6 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  labels:
-    - key: 'jdk.vendor'
-      value: 'openjdk'
-    - key: 'jdk.version'
-      value: '8u181'
-    # isRegex requires container-structure-test v1.7.0
-    #- key: 'jdk.source'
-    #  value: 'openjdk-8-jre-headless 8u181-*'
-    #  isRegex: true
   env:
     - key: 'JAVA_VERSION'
       value: '8u181'

--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -82,6 +82,7 @@ def download_dpkg(package_files, packages, workspace_name):
     """
     pkg_vals_to_package_file_and_sha256 = {}
     package_to_rule_map = {}
+    package_to_version_map = {}
     package_file_to_metadata = {}
     for pkg_vals in set(packages.split(",")):
         pkg_split = pkg_vals.split("=")
@@ -102,6 +103,7 @@ def download_dpkg(package_files, packages, workspace_name):
                 pkg = metadata[pkg_name]
                 buf = urllib.request.urlopen(pkg[FILENAME_KEY])
                 package_to_rule_map[pkg_name] = util.package_to_rule(workspace_name, pkg_name)
+                package_to_version_map[pkg_name] = metadata[pkg_name][VERSION_KEY]
                 out_file = os.path.join("file", util.encode_package_name(pkg_name))
                 with io.open(out_file, 'wb') as f:
                     f.write(buf.read())
@@ -124,6 +126,7 @@ def download_dpkg(package_files, packages, workspace_name):
             raise Exception("Package: %s, Version: %s not found in any of the sources" % (pkg_name, pkg_version))
     with open(PACKAGE_MAP_FILE_NAME, 'w') as f:
         f.write("packages = " + json.dumps(package_to_rule_map))
+        f.write("\nversions = " + json.dumps(package_to_version_map))
 
 def download_package_list(mirror_url, distro, arch, snapshot, sha256, packages_gz_url, package_prefix):
     """Downloads a debian package list, expands the relative urls,

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def package_manager_repositories():
   http_file(
       name = "dpkg_parser",
-      urls = [('https://storage.googleapis.com/distroless/package_manager_tools/b35d94bc3d9690d7fcb455a0e06d0e29fa39484b/dpkg_parser.par')],
+      urls = [('https://storage.googleapis.com/distroless/package_manager_tools/548be30ea343ebf1e3729e1334b8adca8957e0c1/dpkg_parser.par')],
       executable = True,
-      sha256 = "f3bf992f0deba05881599391bd851f90e82cbc4748150247b466863fe3639567",
+      sha256 = "2ca62e67ce4d79a3f4072908559beef9f9c15e1a0f8dbc72a92c046f7c0c9df6",
   )


### PR DESCRIPTION
#276 requests that the `java` images provide information as to the JRE version. This PR follows on from #290 and adds the following metadata to the `distroless/java` images:
  - it sets a `JAVA_VERSION` environment variable to the JRE version, currently `8u181` for the Java 8 image and `11.0.1` for the Java 11 image
  - ~~it sets three labels:~~
    - ~~`jdk.vendor` is hard-coded to `openjdk` since we explicitly select the `openjdk-*-jre-headless` packages~~
    - ~~`jdk.version` is the same release number reported in `JAVA_VERSION`~~
    - ~~`jdk.source` records soe provenance information listing the Debian package name and version: currently `openjdk-8-jre-headless 8u181-b13-2~deb9u1` and `openjdk-11-jre-headless 11.0.1+13-2~bpo9+1`~~

_Update: I'm not convinced of these label keys, and since environment variables are as easy to access as labels, the `JAVA_VERSION` will do for now._

It adds some metadata tests too ~~though the `jdk.source` tests are commented out as they require container-structure-test v1.7.0 (bazelbuild/rules_docker#685)~~.

~~I'm not particularly enamoured by the label names.~~  My priority is the `JAVA_VERSION` environment variable.