### PR TITLE
Use container-friendly arguments for Java 8 images

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -17,17 +17,31 @@ cacerts_java(
         packages[jre_deb],
     ],
     entrypoint = ["/usr/bin/java"] + java_vm_args + ["-jar"],
-        # We expect users to use:
-        # cmd = ["/path/to/deploy.jar", "--option1", ...]
+    # We expect users to use:
+    # cmd = ["/path/to/deploy.jar", "--option1", ...]
     symlinks = {
         "/usr/bin/java": java_executable_path,
     },
     tars = [":cacerts_java"],
 ) for (rule_name, jre_deb, java_executable_path, java_vm_args) in [
-    ("java8", "openjdk-8-jre-headless", "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
-      ["-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap"]),
-    ("java8_debug", "openjdk-8-jre-headless", "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
-      ["-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap"]),
+    (
+        "java8",
+        "openjdk-8-jre-headless",
+        "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
+        [
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+UseCGroupMemoryLimitForHeap",
+        ],
+    ),
+    (
+        "java8_debug",
+        "openjdk-8-jre-headless",
+        "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
+        [
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+UseCGroupMemoryLimitForHeap",
+        ],
+    ),
     ("java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
     ("java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
 ]]

--- a/java/BUILD
+++ b/java/BUILD
@@ -17,39 +17,40 @@ cacerts_java(
         packages["zlib1g"],
         packages[jre_deb],
     ],
-    entrypoint = ["/usr/bin/java"] + java_vm_args + ["-jar"],
-    # We expect users to use:
-    # cmd = ["/path/to/deploy.jar", "--option1", ...]
-    env = {
+    entrypoint = [
+        "/usr/bin/java",
+        "-jar",
+        # We expect users to use:
+        # cmd = ["/path/to/deploy.jar", "--option1", ...]
+    ],
+    env = java_env + {
         "JAVA_VERSION": jre_ver(versions[jre_deb]),
     },
     symlinks = {
         "/usr/bin/java": java_executable_path,
     },
     tars = [":cacerts_java"],
-) for (rule_name, jre_deb, java_executable_path, java_vm_args) in [
+) for (rule_name, jre_deb, java_executable_path, java_env) in [
     (
         "java8",
         "openjdk-8-jre-headless",
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
-        [
+        {
             # special container flags are unnecessary with 1.8.0_191 and beyond
-            "-XX:+UnlockExperimentalVMOptions",
-            "-XX:+UseCGroupMemoryLimitForHeap",
-        ],
+            "_JAVA_OPTIONS": "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap",
+        },
     ),
     (
         "java8_debug",
         "openjdk-8-jre-headless",
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
-        [
+        {
             # special container flags are unnecessary with 1.8.0_191 and beyond
-            "-XX:+UnlockExperimentalVMOptions",
-            "-XX:+UseCGroupMemoryLimitForHeap",
-        ],
+            "_JAVA_OPTIONS": "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap",
+        },
     ),
-    ("java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
-    ("java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
+    ("java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", {}),
+    ("java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", {}),
 ]]
 
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")

--- a/java/BUILD
+++ b/java/BUILD
@@ -16,21 +16,20 @@ cacerts_java(
         packages["zlib1g"],
         packages[jre_deb],
     ],
-    entrypoint = [
-        "/usr/bin/java",
-        "-jar",
+    entrypoint = ["/usr/bin/java"] + java_vm_args + ["-jar"],
         # We expect users to use:
         # cmd = ["/path/to/deploy.jar", "--option1", ...]
-    ],
     symlinks = {
         "/usr/bin/java": java_executable_path,
     },
     tars = [":cacerts_java"],
-) for (rule_name, jre_deb, java_executable_path) in [
-    ("java8", "openjdk-8-jre-headless", "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"),
-    ("java8_debug", "openjdk-8-jre-headless", "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"),
-    ("java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"),
-    ("java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"),
+) for (rule_name, jre_deb, java_executable_path, java_vm_args) in [
+    ("java8", "openjdk-8-jre-headless", "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
+      ["-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap"]),
+    ("java8_debug", "openjdk-8-jre-headless", "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
+      ["-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap"]),
+    ("java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
+    ("java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
 ]]
 
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")

--- a/java/BUILD
+++ b/java/BUILD
@@ -29,6 +29,7 @@ cacerts_java(
         "openjdk-8-jre-headless",
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
         [
+            # special container flags are unnecessary with 1.8.0_191 and beyond
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+UseCGroupMemoryLimitForHeap",
         ],
@@ -38,6 +39,7 @@ cacerts_java(
         "openjdk-8-jre-headless",
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
         [
+            # special container flags are unnecessary with 1.8.0_191 and beyond
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+UseCGroupMemoryLimitForHeap",
         ],

--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -19,7 +19,9 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]
+  entrypoint: ["/usr/bin/java", "-jar"]
   env:
     - key: 'JAVA_VERSION'
       value: '8u181'
+    - key: '_JAVA_OPTIONS'
+      value: '-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap'

--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -1,10 +1,12 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 commandTests:
   - name: java
-    command: ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-version"]
+    command: "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
   - name: java-symlink
-    command: ["/usr/bin/java", "-version"]
+    command: "/usr/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
 fileExistenceTests:
   - name: certs
@@ -16,3 +18,6 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+metadataTest:
+  entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]
+

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -19,7 +19,9 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]
+  entrypoint: ["/usr/bin/java", "-jar"]
   env:
     - key: 'JAVA_VERSION'
       value: '8u181'
+    - key: '_JAVA_OPTIONS'
+      value: '-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap'

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -1,10 +1,12 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 commandTests:
   - name: java
-    command: ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-version"]
+    command: "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
   - name: java-symlink
-    command: ["/usr/bin/java", "-version"]
+    command: "/usr/bin/java"
+    args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
 fileExistenceTests:
   - name: certs
@@ -16,3 +18,5 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+metadataTest:
+  entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]


### PR DESCRIPTION
Update Java 8 images to use `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap`.

Fixes #289