### PR TITLE
WORKSPACE: Use https for Jetty: https://repo1.maven.org

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,7 +158,7 @@ http_archive(
     sha256 = "c66abd7323f6df5b28690e145d2ae829dbd12b8a2923266fa23ab5139a9303c5",
     strip_prefix = "jetty-distribution-9.4.14.v20181114/",
     type = "tar.gz",
-    urls = ["http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.14.v20181114/jetty-distribution-9.4.14.v20181114.tar.gz"],
+    urls = ["https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.14.v20181114/jetty-distribution-9.4.14.v20181114.tar.gz"],
 )
 
 # Node


### PR DESCRIPTION
This appears to be the new "maintained" Maven repository URL. At the very
least it is the URL that Bazel itself uses:

https://github.com/bazelbuild/bazel/blob/master/tools/build_defs/repo/maven_rules.bzl