### PR TITLE
Add libjpeg62-turbo Debian package to Java images

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,6 +81,7 @@ dpkg_list(
 
         #java
         "zlib1g",
+        "libjpeg62-turbo",
         "openjdk-8-jre-headless",
         "openjdk-11-jre-headless",
 

--- a/java/BUILD
+++ b/java/BUILD
@@ -15,6 +15,7 @@ cacerts_java(
     base = "//cc" if (not ("debug" in rule_name)) else "//cc:debug",
     debs = [
         packages["zlib1g"],
+        packages["libjpeg62-turbo"],
         packages[jre_deb],
     ],
     entrypoint = [


### PR DESCRIPTION
Fixes #300.

[`libjpeg62-turbo` provides `libjpeg.so.62`.](
https://packages.debian.org/stretch/amd64/libjpeg62-turbo/filelist)