### PR TITLE
Rework #295 to specify container-friendly args in entrypoint

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -17,40 +17,39 @@ cacerts_java(
         packages["zlib1g"],
         packages[jre_deb],
     ],
-    entrypoint = [
-        "/usr/bin/java",
-        "-jar",
-        # We expect users to use:
-        # cmd = ["/path/to/deploy.jar", "--option1", ...]
-    ],
-    env = java_env + {
+    entrypoint = ["/usr/bin/java"] + java_vm_args + ["-jar"],
+    # We expect users to use:
+    # cmd = ["/path/to/deploy.jar", "--option1", ...]
+    env = {
         "JAVA_VERSION": jre_ver(versions[jre_deb]),
     },
     symlinks = {
         "/usr/bin/java": java_executable_path,
     },
     tars = [":cacerts_java"],
-) for (rule_name, jre_deb, java_executable_path, java_env) in [
+) for (rule_name, jre_deb, java_executable_path, java_vm_args) in [
     (
         "java8",
         "openjdk-8-jre-headless",
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
-        {
+        [
             # special container flags are unnecessary with 1.8.0_191 and beyond
-            "_JAVA_OPTIONS": "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap",
-        },
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+UseCGroupMemoryLimitForHeap",
+        ],
     ),
     (
         "java8_debug",
         "openjdk-8-jre-headless",
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
-        {
+        [
             # special container flags are unnecessary with 1.8.0_191 and beyond
-            "_JAVA_OPTIONS": "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap",
-        },
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+UseCGroupMemoryLimitForHeap",
+        ],
     ),
-    ("java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", {}),
-    ("java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", {}),
+    ("java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
+    ("java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
 ]]
 
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")

--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -19,9 +19,7 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  entrypoint: ["/usr/bin/java", "-jar"]
+  entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]
   env:
     - key: 'JAVA_VERSION'
       value: '8u181'
-    - key: '_JAVA_OPTIONS'
-      value: '-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap'

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -19,9 +19,7 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  entrypoint: ["/usr/bin/java", "-jar"]
+  entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]
   env:
     - key: 'JAVA_VERSION'
       value: '8u181'
-    - key: '_JAVA_OPTIONS'
-      value: '-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap'


### PR DESCRIPTION
I have significant misgivings about using `_JAVA_OPTIONS`: as `java` outputs even when the variable is an empty string, and it's hard to unset an environment variable once set:
```sh
$ set _JAVA_OPTIONS=-Xms45m
$ _JAVA_OPTIONS="" java -version
Picked up _JAVA_OPTIONS: 
java version "1.8.0_192"
Java(TM) SE Runtime Environment (build 1.8.0_192-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.192-b12, mixed mode)
```
I fear this will break tests and tools that expect to produce useful output.

This PR reverts to my first approach in #295 and passes the container-friendly arguments on the command-line, fixing #289.  It's not as inheritable, but it doesn't change behaviour.