### PR TITLE
Build Jetty-on-Java 11 images

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,6 +17,8 @@ container_bundle(
         "gcr.io/{PROJECT_ID}/java/jetty:java8": "//java/jetty:jetty_java8",
         "gcr.io/{PROJECT_ID}/java/jetty:debug": "//java/jetty:jetty_java8_debug",
         "gcr.io/{PROJECT_ID}/java/jetty:java8-debug": "//java/jetty:jetty_java8_debug",
+        "gcr.io/{PROJECT_ID}/java/jetty:java11": "//java/jetty:jetty_java11",
+        "gcr.io/{PROJECT_ID}/java/jetty:java11-debug": "//java/jetty:jetty_java11_debug",
         "gcr.io/{PROJECT_ID}/python3:latest": "//experimental/python3:python3",
         "gcr.io/{PROJECT_ID}/python3:debug": "//experimental/python3:debug",
         "gcr.io/{PROJECT_ID}/python2.7:latest": "//experimental/python2.7:python27",

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -62,6 +62,16 @@ steps:
   args: ['tag', 'bazel/java/jetty:jetty_java8_debug', 'gcr.io/$PROJECT_ID/java/jetty:java8-debug']
 
 - name: gcr.io/cloud-builders/bazel
+  args: ['run', '//java/jetty:jetty_java11']
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'bazel/java/jetty:jetty_java11', 'gcr.io/$PROJECT_ID/java/jetty:java11']
+
+- name: gcr.io/cloud-builders/bazel
+  args: ['run', '//java/jetty:jetty_java11_debug']
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'bazel/java/jetty:jetty_java11_debug', 'gcr.io/$PROJECT_ID/java/jetty:java11-debug']
+
+- name: gcr.io/cloud-builders/bazel
   args: ['run', '//experimental/python3:python3']
 - name: gcr.io/cloud-builders/docker
   args: ['tag', 'bazel/experimental/python3:python3', 'gcr.io/$PROJECT_ID/python3:latest']

--- a/java/jetty/BUILD
+++ b/java/jetty/BUILD
@@ -16,3 +16,29 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
     ("jetty_java11", "//java:java11"),
     ("jetty_java11_debug", "//java:java11_debug"),
 ]]
+
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+
+container_test(
+    name = "jetty_java8_test",
+    configs = ["testdata/java8.yaml"],
+    image = ":jetty_java8",
+)
+
+container_test(
+    name = "jetty_java8_debug_test",
+    configs = ["testdata/java8_debug.yaml"],
+    image = ":jetty_java8_debug",
+)
+
+container_test(
+    name = "jetty_java11_test",
+    configs = ["testdata/java11.yaml"],
+    image = ":jetty_java11",
+)
+
+container_test(
+    name = "jetty_java11_debug_test",
+    configs = ["testdata/java11_debug.yaml"],
+    image = ":jetty_java11_debug",
+)

--- a/java/jetty/BUILD
+++ b/java/jetty/BUILD
@@ -4,13 +4,15 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 [container_image(
     name = rule_name,
-    base = "//java:java8" if (not ("debug" in rule_name)) else "//java:java8_debug",
+    base = base_image,
     cmd = ["/jetty/start.jar"],
     ports = ["8080"],
     tars = ["@jetty//:tar"],
     workdir = "/jetty",
     # We expect users to add their WAR under /jetty/webapps.
-) for rule_name in [
-    "jetty_java8",
-    "jetty_java8_debug",
+) for (rule_name, base_image) in [
+    ("jetty_java8", "//java:java8"),
+    ("jetty_java8_debug", "//java:java8_debug"),
+    ("jetty_java11", "//java:java11"),
+    ("jetty_java11_debug", "//java:java11_debug"),
 ]]

--- a/java/jetty/testdata/java11.yaml
+++ b/java/jetty/testdata/java11.yaml
@@ -1,0 +1,25 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: jetty
+    command: "/usr/bin/java"
+    args: ["-jar", "/jetty/start.jar", "--version"]
+    expectedOutput: ['.*Jetty Server Classpath:.*']
+  - name: java
+    command: "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "11\.*']
+  - name: java-symlink
+    command: "/usr/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "11\.*']
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: busybox
+    path: "/busybox/sh"
+    shouldExist: false
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+    

--- a/java/jetty/testdata/java11.yaml
+++ b/java/jetty/testdata/java11.yaml
@@ -22,4 +22,3 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
-    

--- a/java/jetty/testdata/java11_debug.yaml
+++ b/java/jetty/testdata/java11_debug.yaml
@@ -22,4 +22,3 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
-    

--- a/java/jetty/testdata/java11_debug.yaml
+++ b/java/jetty/testdata/java11_debug.yaml
@@ -1,0 +1,25 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: jetty
+    command: "/usr/bin/java"
+    args: ["-jar", "/jetty/start.jar", "--version"]
+    expectedOutput: ['.*Jetty Server Classpath:.*']
+  - name: java
+    command: "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "11\.*']
+  - name: java-symlink
+    command: "/usr/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "11\.*']
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: busybox
+    path: "/busybox/sh"
+    shouldExist: true
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+    

--- a/java/jetty/testdata/java8.yaml
+++ b/java/jetty/testdata/java8.yaml
@@ -1,0 +1,25 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: jetty
+    command: "/usr/bin/java"
+    args: ["-jar", "/jetty/start.jar", "--version"]
+    expectedOutput: ['.*Jetty Server Classpath:.*']
+  - name: java
+    command: "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "1\.8.*"']
+  - name: java-symlink
+    command: "/usr/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "1\.8.*"']
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: busybox
+    path: "/busybox/sh"
+    shouldExist: false
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+    

--- a/java/jetty/testdata/java8.yaml
+++ b/java/jetty/testdata/java8.yaml
@@ -22,4 +22,3 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
-    

--- a/java/jetty/testdata/java8_debug.yaml
+++ b/java/jetty/testdata/java8_debug.yaml
@@ -22,4 +22,3 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
-   

--- a/java/jetty/testdata/java8_debug.yaml
+++ b/java/jetty/testdata/java8_debug.yaml
@@ -1,0 +1,25 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: jetty
+    command: "/usr/bin/java"
+    args: ["-jar", "/jetty/start.jar", "--version"]
+    expectedOutput: ['.*Jetty Server Classpath:.*']
+  - name: java
+    command: "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "1\.8.*"']
+  - name: java-symlink
+    command: "/usr/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "1\.8.*"']
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: busybox
+    path: "/busybox/sh"
+    shouldExist: true
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+   


### PR DESCRIPTION
[We install Jetty 9.4.14](https://github.com/GoogleContainerTools/distroless/blob/master/WORKSPACE#L162), and it should be stable on Java 11 runtimes. 

https://www.eclipse.org/lists/jetty-announce/msg00125.html
https://webtide.com/java-updates-jetty-and-the-future/

Verified its actual working with a tiny example.