### PR TITLE
Add group entries for `staff` and `tty`

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -23,17 +23,23 @@ passwd_tar(
     passwd_file_pkg_dir = "etc",
 )
 
-# Create /etc/group with the root group
+# Create /etc/group with the root and staff groups
 group_entry(
     name = "root_group",
     gid = 0,
     groupname = "root",
+)
+group_entry(
+    name = "staff_group",
+    gid = 50,
+    groupname = "staff",
 )
 
 group_file(
     name = "group",
     entries = [
         ":root_group",
+        ":staff_group",
     ],
 )
 

--- a/base/BUILD
+++ b/base/BUILD
@@ -29,11 +29,13 @@ group_entry(
     gid = 0,
     groupname = "root",
 )
+
 group_entry(
     name = "tty_group",
     gid = 5,
     groupname = "tty",
 )
+
 group_entry(
     name = "staff_group",
     gid = 50,

--- a/base/BUILD
+++ b/base/BUILD
@@ -23,11 +23,16 @@ passwd_tar(
     passwd_file_pkg_dir = "etc",
 )
 
-# Create /etc/group with the root and staff groups
+# Create /etc/group with the root, tty, and staff groups
 group_entry(
     name = "root_group",
     gid = 0,
     groupname = "root",
+)
+group_entry(
+    name = "tty_group",
+    gid = 5,
+    groupname = "tty",
 )
 group_entry(
     name = "staff_group",
@@ -39,6 +44,7 @@ group_file(
     name = "group",
     entries = [
         ":root_group",
+        ":tty_group",
         ":staff_group",
     ],
 )

--- a/base/testdata/base.yaml
+++ b/base/testdata/base.yaml
@@ -37,4 +37,4 @@ fileContentTests:
   expectedContents: ['^root:x:0:0:user:/home:/bin/bash\n$']
 - name: 'known groups'
   path: '/etc/group'
-  expectedContents: ['^root:x:0:\nstaff:x:50:\n$']
+  expectedContents: ['^root:x:0:\ntty:x:5:\nstaff:x:50:\n$']

--- a/base/testdata/base.yaml
+++ b/base/testdata/base.yaml
@@ -10,6 +10,9 @@ fileExistenceTests:
 - name: passwd
   path: '/etc/passwd'
   shouldExist: true
+- name: group
+  path: '/etc/group'
+  shouldExist: true
 - name: etc-os-release
   path: '/etc/os-release'
   shouldExist: true
@@ -28,3 +31,10 @@ fileExistenceTests:
 - name: homedir
   path: '/home'
   shouldExist: true
+fileContentTests:
+- name: 'known users'
+  path: '/etc/passwd'
+  expectedContents: ['^root:x:0:0:user:/home:/bin/bash\n$']
+- name: 'known groups'
+  path: '/etc/group'
+  expectedContents: ['^root:x:0:\nstaff:x:50:\n$']


### PR DESCRIPTION
This PR is purely cosmetic and adds two entries to `/etc/group` for `staff` (gid 50) and `tty` (gid 5).

distroless/base configures `/etc/group` to only include a `root` group.  But Debian's `base-files` package adds `/var/local` which is owned by `0:50`, and `/dev/console` and `/dev/pts/0` have group `5`.  In Debian, group 5 is `tty` and group 50 is `staff`.

----
`busybox`'s `find` doesn't support `-nouser` nor `-nogroup`, but the following command verifies there are no other unowned files or directories:
```
$ find / \! \( -user 0 -a \( -group 0 -o -group 5 -o -group 50 \) \) -exec ls -l {} \;
```
