### PR TITLE
Update snapshots to pull in latest Java 8 (8u212)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,7 +29,7 @@ dpkg_src(
     arch = "amd64",
     distro = "stretch",
     sha256 = "79a66cd92ba9096fce679e15d0b5feb9effcf618b0a6d065eb32684dbffd0311",
-    snapshot = "20190227T154250Z",
+    snapshot = "20190322T151132Z",
     url = "https://snapshot.debian.org/archive",
 )
 
@@ -37,16 +37,16 @@ dpkg_src(
     name = "debian_stretch_backports",
     arch = "amd64",
     distro = "stretch-backports",
-    sha256 = "c033a0e3c9a3e5d3c1370b37b8ad2f216c30a84aff14a4ed0c8f4bdfe3319fbf",
-    snapshot = "20190227T154250Z",
+    sha256 = "36b3c35b2c01d22476736b0c26e6037dddeccf1d7a775b3fbd5dd991b58cceab",
+    snapshot = "20190322T155353Z",
     url = "https://snapshot.debian.org/archive",
 )
 
 dpkg_src(
     name = "debian_stretch_security",
-    package_prefix = "https://snapshot.debian.org/archive/debian-security/20190227T200358Z/",
-    packages_gz_url = "https://snapshot.debian.org/archive/debian-security/20190227T200358Z/dists/stretch/updates/main/binary-amd64/Packages.gz",
-    sha256 = "4e99e75431dd58840d084a5fddb950ebc8b4c634becaddb717773b05e321bdf4",
+    package_prefix = "https://snapshot.debian.org/archive/debian-security/20190322T155353Z/",
+    packages_gz_url = "https://snapshot.debian.org/archive/debian-security/20190322T155353Z/dists/stretch/updates/main/binary-amd64/Packages.gz",
+    sha256 = "5dc5641648e7773dcd14e5ac2afd1803e8639b8b793ac5975793f8e98908d8ff",
 )
 
 dpkg_list(

--- a/java/BUILD
+++ b/java/BUILD
@@ -24,9 +24,9 @@ cacerts_java(
         packages["libfontconfig1"],
         packages[jre_deb],
     ],
-    entrypoint = ["/usr/bin/java"] + java_vm_args + ["-jar"],
     # We expect users to use:
     # cmd = ["/path/to/deploy.jar", "--option1", ...]
+    entrypoint = ["/usr/bin/java", "-jar"],
     env = {
         "JAVA_VERSION": jre_ver(versions[jre_deb]),
     },
@@ -34,29 +34,19 @@ cacerts_java(
         "/usr/bin/java": java_executable_path,
     },
     tars = [":cacerts_java"],
-) for (rule_name, jre_deb, java_executable_path, java_vm_args) in [
+) for (rule_name, jre_deb, java_executable_path) in [
     (
         "java8",
         "openjdk-8-jre-headless",
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
-        [
-            # special container flags are unnecessary with 1.8.0_191 and beyond
-            "-XX:+UnlockExperimentalVMOptions",
-            "-XX:+UseCGroupMemoryLimitForHeap",
-        ],
     ),
     (
         "java8_debug",
         "openjdk-8-jre-headless",
         "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
-        [
-            # special container flags are unnecessary with 1.8.0_191 and beyond
-            "-XX:+UnlockExperimentalVMOptions",
-            "-XX:+UseCGroupMemoryLimitForHeap",
-        ],
     ),
-    ("java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
-    ("java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java", []),
+    ("java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"),
+    ("java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"),
 ]]
 
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")

--- a/java/BUILD
+++ b/java/BUILD
@@ -26,7 +26,10 @@ cacerts_java(
     ],
     # We expect users to use:
     # cmd = ["/path/to/deploy.jar", "--option1", ...]
-    entrypoint = ["/usr/bin/java", "-jar"],
+    entrypoint = [
+        "/usr/bin/java",
+        "-jar",
+    ],
     env = {
         "JAVA_VERSION": jre_ver(versions[jre_deb]),
     },

--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -19,7 +19,7 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]
+  entrypoint: ["/usr/bin/java", "-jar"]
   env:
     - key: 'JAVA_VERSION'
       value: '8u212'

--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -22,4 +22,4 @@ metadataTest:
   entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]
   env:
     - key: 'JAVA_VERSION'
-      value: '8u181'
+      value: '8u212'

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -19,7 +19,7 @@ fileExistenceTests:
     path: "/bin/sh"
     shouldExist: false
 metadataTest:
-  entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]
+  entrypoint: ["/usr/bin/java", "-jar"]
   env:
     - key: 'JAVA_VERSION'
       value: '8u212'

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -22,4 +22,4 @@ metadataTest:
   entrypoint: ["/usr/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar"]
   env:
     - key: 'JAVA_VERSION'
-      value: '8u181'
+      value: '8u212'


### PR DESCRIPTION
Fixes #293 #331.

Locally built Java 8 shows 8u212. Yeah!
```
$ docker run --rm bazel/java:java8_debug -version
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (build 1.8.0_212-8u212-b01-1~deb9u1-b01)
OpenJDK 64-Bit Server VM (build 25.212-b01, mixed mode)
```