### PR TITLE
Make buildifier be helpful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jdk:
 
 install:
   - export PATH=$PATH:$HOME/bin && mkdir -p $HOME/bin
-  - wget https://github.com/bazelbuild/buildtools/releases/download/0.11.1/buildifier && chmod +x buildifier && mv buildifier $HOME/bin/
+  - wget https://github.com/bazelbuild/buildtools/releases/download/0.22.0/buildifier && chmod +x buildifier && mv buildifier $HOME/bin/
   - wget https://github.com/bazelbuild/bazel/releases/download/0.19.2/bazel-0.19.2-linux-x86_64 && mv bazel-0.19.2-linux-x86_64 bazel && chmod +x bazel && mv bazel $HOME/bin/
   - sudo pip install pylint
   

--- a/BUILD
+++ b/BUILD
@@ -32,8 +32,4 @@ container_bundle(
 
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "container_push")
 
-container_push(
-    name = "publish",
-    bundle = ":all",
-    format = "Docker",
-)
+container_push(name = "publish", bundle = ":all", format = "Docker")

--- a/BUILD
+++ b/BUILD
@@ -32,4 +32,8 @@ container_bundle(
 
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "container_push")
 
-container_push(name = "publish", bundle = ":all", format = "Docker")
+container_push(
+    name = "publish",
+    bundle = ":all",
+    format = "Docker",
+)

--- a/buildifier.sh
+++ b/buildifier.sh
@@ -16,8 +16,6 @@
 
 buildifier -mode=diff $(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)
 if [ $? -ne 0 ]; then
-  if [[ $files ]]; then
-    echo "Run 'buildifier -mode fix \$(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)' to fix formatting"
-  fi
+  echo "Run 'buildifier -mode=fix \$(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)' to fix formatting"
   exit 1
 fi

--- a/buildifier.sh
+++ b/buildifier.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-files=$(buildifier -mode=check $(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f))
+buildifier -mode=diff $(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)
 if [ $? -ne 0 ]; then
   if [[ $files ]]; then
     echo "Run 'buildifier -mode fix \$(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)' to fix formatting"


### PR DESCRIPTION
Change `buildifier.sh` to run with `-mode=diff` to report suggested changes.  Requires updating to 0.22.0 so `-mode=diff` errors on change.

Example of failure at https://travis-ci.org/GoogleContainerTools/distroless/builds/511137529 (raw log: 
https://api.travis-ci.org/v3/job/511137530/log.txt)