### PR TITLE
Set -diff_command to use command-line diff tool when calling buildifier

### DIFF
--- a/buildifier.sh
+++ b/buildifier.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-buildifier -mode=diff $(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)
+buildifier -mode=diff -diff_command='diff -u' $(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)
 if [ $? -ne 0 ]; then
   echo "Run 'buildifier -mode=fix \$(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)' to fix formatting"
   exit 1


### PR DESCRIPTION
On my machine, I have `DISPLAY=:0` defined, and seems like `buildifier` tries to be smart to bring up a GUI diff (`/usr/bin/tkdiff`), which is annoying.

```
$ ./buildifier.sh 
buildifier: selecting diff program with the BUILDIFIER_DIFF, BUILDIFIER_MULTIDIFF, and DISPLAY environment variables is deprecated, use flags -diff_command and -multi_diff instead
./base/BUILD:
/usr/bin/tkdiff: 37: exec: /usr/local/old_symlinks/tkdiff: Required key not available
exit status 2
Run 'buildifier -mode=fix $(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)' to fix formatting
```