### PR TITLE
Update image to extract java ca certs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ jdk:
 install:
   - export PATH=$PATH:$HOME/bin && mkdir -p $HOME/bin
   - wget https://github.com/bazelbuild/buildtools/releases/download/0.22.0/buildifier && chmod +x buildifier && mv buildifier $HOME/bin/
-  - wget https://github.com/bazelbuild/bazel/releases/download/0.19.2/bazel-0.19.2-linux-x86_64 && mv bazel-0.19.2-linux-x86_64 bazel && chmod +x bazel && mv bazel $HOME/bin/
+  - wget https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel-0.24.0-linux-x86_64 && mv bazel-0.24.0-linux-x86_64 bazel && chmod +x bazel && mv bazel $HOME/bin/
   - sudo pip install pylint
-  
 
 script:
   - ./test.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -214,11 +214,11 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 # Used to generate java ca certs.
 container_pull(
-    name = "debian8",
-    # From tag: 2017-09-11-115552
-    digest = "sha256:6d381d0bf292e31291136cff03b3209eb40ef6342fb790483fa1b9d3af84ae46",
+    name = "debian9",
+    # From tag: 2019-02-27-130449
+    digest = "sha256:fd26dfa474b76ef931e439537daba90bbd90d6c5bbdd0252616e6d87251cd9cd",
     registry = "gcr.io",
-    repository = "google-appengine/debian8",
+    repository = "google-appengine/debian9",
 )
 
 # Have the py_image dependencies for testing.

--- a/cacerts/java.bzl
+++ b/cacerts/java.bzl
@@ -27,7 +27,8 @@ def _impl(ctx):
 set -ex
 docker load -i {0}
 # Install the certs in the builder image.
-cid=$(docker run -d {1} sh -c "apt-get update && apt-get install -y -q ca-certificates-java")
+# ln: the default non-interactive shell is dash, which interferes with the post install script.
+cid=$(docker run -d {1} sh -c "ln -sf bash /bin/sh && apt-get update && apt-get install -y -q ca-certificates-java")
 docker attach $cid
 
 # Copy out the certs as a tarball

--- a/cacerts/java.bzl
+++ b/cacerts/java.bzl
@@ -58,7 +58,7 @@ docker rm $cid
 cacerts_java = rule(
     attrs = {
         "_builder_image": attr.label(
-            default = Label("@debian8//image:image.tar"),
+            default = Label("@debian9//image:image.tar"),
             allow_files = True,
             single_file = True,
         ),


### PR DESCRIPTION
Fixes #342.

Note we have tests to connect to www.google.com, such as [this](https://github.com/GoogleContainerTools/distroless/blob/master/java/testdata/java8_certs.yaml).