### PR TITLE
Fix formatting

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,16 +15,8 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
-load(
-    "//package_manager:package_manager.bzl",
-    "package_manager_repositories"
-)
-
-load(
-    "//package_manager:dpkg.bzl",
-    "dpkg_list",
-    "dpkg_src"
-)
+load("//package_manager:package_manager.bzl", "package_manager_repositories")
+load("//package_manager:dpkg.bzl", "dpkg_list", "dpkg_src")
 
 package_manager_repositories()
 


### PR DESCRIPTION
`buildifier.sh` was complaining with missing commas. I made them one-liners, and it's happy.

```diff
$ ./buildifier.sh
./WORKSPACE:
--- ./WORKSPACE 2019-05-10 18:35:53.814959377 -0400
+++ /tmp/buildifier-tmp-667848469       2019-05-10 18:36:53.370703568 -0400
@@ -17,13 +17,12 @@

 load(
     "//package_manager:package_manager.bzl",
-    "package_manager_repositories"
+    "package_manager_repositories",
 )
-
 load(
     "//package_manager:dpkg.bzl",
     "dpkg_list",
-    "dpkg_src"
+    "dpkg_src",
 )

 package_manager_repositories()
```