### PR TITLE
Update Golang version to 1.12 in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Follow these steps to get started:
 
   ```dockerfile
   # Start by building the application.
-  FROM golang:1.8 as build
+  FROM golang:1.12 as build
 
   WORKDIR /go/src/app
   COPY . .

--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8 as build-env
+FROM golang:1.12 as build-env
 
 WORKDIR /go/src/app
 ADD . /go/src/app


### PR DESCRIPTION
The latest version Go 1.12 was released on 25 February 2019 and around 2.5 months passed since then.

## Refs

- https://blog.golang.org/go1.12


Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>