### PR TITLE
Update for compatibility with bazel --incompatible_no_transitive_loads

### DIFF
--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -1,4 +1,4 @@
-load(":dpkg.bzl", "dpkg_list", "dpkg_src")
+load(":dpkg.bzl", _dpkg_list = "dpkg_list", _dpkg_src = "dpkg_src")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 def package_manager_repositories():

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -8,3 +8,7 @@ def package_manager_repositories():
       executable = True,
       sha256 = "2ca62e67ce4d79a3f4072908559beef9f9c15e1a0f8dbc72a92c046f7c0c9df6",
   )
+  
+# Re-export symbols for compatibility with --incompatible_no_transitive_loads
+dpkg_list = _dpkg_list
+dpkg_src = _dpkg_src


### PR DESCRIPTION
Newer versions of bazel don't transitively export functions from starlark files.  
This change explicitly exports the dpkg functions.