### PR TITLE
fix container_tests on darwin

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -152,6 +152,8 @@ container_test(
 go_binary(
     name = "check_certs",
     srcs = ["testdata/check_certs.go"],
+    # Test image is linux based
+    goos = "linux",
     pure = "on",
 )
 

--- a/examples/nonroot/BUILD
+++ b/examples/nonroot/BUILD
@@ -40,6 +40,7 @@ container_image(
 go_binary(
     name = "user",
     srcs = ["testdata/user.go"],
+    goos = "linux",
     pure = "on",
 )
 

--- a/examples/nonroot/BUILD
+++ b/examples/nonroot/BUILD
@@ -40,6 +40,7 @@ container_image(
 go_binary(
     name = "user",
     srcs = ["testdata/user.go"],
+    # Test image is linux based
     goos = "linux",
     pure = "on",
 )


### PR DESCRIPTION
Go binary was being compiled with `darwin` GOOS. We should use Linux since this binary runs in a Linux Container.