### PR TITLE
Fix breaking changes from Bazel 0.27

### DIFF
--- a/cacerts/cacerts.bzl
+++ b/cacerts/cacerts.bzl
@@ -1,22 +1,21 @@
 """A rule to unpack ca certificates from the debian package."""
 
 def _impl(ctx):
-    args = "%s %s %s %s" % (
-	ctx.executable._extract.path,
-	ctx.file.deb.path,
-	ctx.outputs.tar.path,
-	ctx.outputs.deb.path,
+    ctx.actions.run(
+        executable = ctx.executable._extract,
+        arguments = [
+            ctx.file.deb.path,
+            ctx.outputs.tar.path,
+            ctx.outputs.deb.path
+        ],
+        inputs = [ctx.file.deb],
+        outputs = [ctx.outputs.tar, ctx.outputs.deb],
     )
-
-    ctx.action(command = args,
-            inputs = [ctx.executable._extract, ctx.file.deb],
-            outputs = [ctx.outputs.tar, ctx.outputs.deb])
 
 cacerts = rule(
     attrs = {
         "deb": attr.label(
-            allow_files = [".deb"],
-            single_file = True,
+            allow_single_file = [".deb"],
             mandatory = True,
         ),
         # Implicit dependencies.

--- a/cacerts/java.bzl
+++ b/cacerts/java.bzl
@@ -42,7 +42,7 @@ docker rm $cid
             builder_image_name,
             ctx.outputs.out.path)
     script = ctx.actions.declare_file("cacerts.build")
-    ctx.file_action(
+    ctx.actions.write(
         output=script,
         content=build_contents,
     )
@@ -60,8 +60,7 @@ cacerts_java = rule(
     attrs = {
         "_builder_image": attr.label(
             default = Label("@debian9//image:image.tar"),
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
     },
     executable = False,

--- a/package_manager/dpkg.bzl
+++ b/package_manager/dpkg.bzl
@@ -7,14 +7,14 @@ exports_files(deb_files + ["packages.bzl"])
 
   args = [
       repository_ctx.path(repository_ctx.attr._dpkg_parser),
-      "--package-files", ",".join([repository_ctx.path(src_path) for src_path in repository_ctx.attr.sources]),
+      "--package-files", ",".join([str(repository_ctx.path(src_path)) for src_path in repository_ctx.attr.sources]),
       "--packages", ",".join(repository_ctx.attr.packages),
       "--workspace-name", repository_ctx.name,
   ]
 
   result = repository_ctx.execute(args)
   if result.return_code:
-    fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join(args)))
+    fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join([str(a) for a in args])))
 
 _dpkg_list = repository_rule(
     _dpkg_list_impl,
@@ -50,7 +50,7 @@ exports_files(["Packages.json", "os_release.tar"])
 
   result = repository_ctx.execute(args)
   if result.return_code:
-    fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join(args)))
+    fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join([str(a) for a in args])))
 
 _dpkg_src = repository_rule(
     _dpkg_src_impl,


### PR DESCRIPTION
Fixes for:
- --incompatible_new_actions_api
- --incompatible_disable_deprecated_attr_params
- --incompatible_no_support_tools_in_action_inputs
- --incompatible_string_join_requires_strings