### PR TITLE
Make busybox package public

### DIFF
--- a/experimental/busybox/BUILD
+++ b/experimental/busybox/BUILD
@@ -1,4 +1,4 @@
-package(default_visibility = ["//base:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load(":commands.bzl", "BUSYBOX_COMMANDS")


### PR DESCRIPTION
Was experimenting creating a different distribution (ie. ubuntu) and realized in order to have debug images we need this package to be public

Right now I just copied the rules
https://github.com/dprotaso/distroless-ubuntu/tree/74094d7189c8b189208b867e72fb9e3252df4821/bionic/busybox