### PR TITLE
Fix build for latest Bazel releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jdk:
 install:
   - export PATH=$PATH:$HOME/bin && mkdir -p $HOME/bin
   - wget https://github.com/bazelbuild/buildtools/releases/download/0.22.0/buildifier && chmod +x buildifier && mv buildifier $HOME/bin/
-  - wget https://github.com/bazelbuild/bazel/releases/download/0.24.0/bazel-0.24.0-linux-x86_64 && mv bazel-0.24.0-linux-x86_64 bazel && chmod +x bazel && mv bazel $HOME/bin/
+  - wget https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-linux-x86_64 && mv bazel-0.28.1-linux-x86_64 bazel && chmod +x bazel && mv bazel $HOME/bin/
   - sudo pip install pylint
 
 script:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,11 +5,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
+    sha256 = "8df59f11fb697743cbb3f26cfb8750395f30471e9eabde0d174c3aebc7a1cd39",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.19.1/rules_go-0.19.1.tar.gz",
+    ],
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -194,9 +197,9 @@ http_file(
 # Docker rules.
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "3556d4972571f288f8c43378295d84ed64fef5b1a875211ee1046f9f6b4258fa",
-    strip_prefix = "rules_docker-0.8.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.8.0.tar.gz"],
+    sha256 = "87fc6a2b128147a0a3039a2fd0b53cc1f2ed5adb8716f50756544a572999ae9a",
+    strip_prefix = "rules_docker-0.8.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.8.1.tar.gz"],
 )
 
 load(

--- a/package_manager/parse_metadata.py
+++ b/package_manager/parse_metadata.py
@@ -22,7 +22,7 @@ SEPARATOR = ":"
 def parse_package_metadata(data, mirror_url, snapshot, package_prefix):
     """ Takes a debian package list, changes the relative urls to absolute urls,
     and saves the resulting metadata as a json file """
-    raw_entries = [line.decode('utf-8').rstrip() for line in data.splitlines()]
+    raw_entries = [line.rstrip() for line in data.splitlines()]
     parsed_entries = {}
     current_key = None
     current_entry = {}

--- a/test.sh
+++ b/test.sh
@@ -18,9 +18,9 @@ set -e
 
 # Linting
 ./buildifier.sh
-find . -name "*.py" |xargs pylint --disable=R,C
+find . -name "*.py" | xargs pylint --disable=R,C
 
 # Bazel build and test
-bazel clean --curses=no
-bazel build --curses=no //...
-bazel test --curses=no --test_output=errors //...
+bazel clean --host_force_python=PY2 --curses=no
+bazel build --host_force_python=PY2 --curses=no //...
+bazel test --host_force_python=PY2 --curses=no --test_output=errors //...


### PR DESCRIPTION
Builds were failing with latest Bazel releases.

Also needed `--host_force_python=PY2` as in [#383](https://github.com/GoogleContainerTools/distroless/pull/383/files). See https://github.com/bazelbuild/rules_docker/issues/842#issuecomment-504143568 for reference.

And now Bazel seems to recognize Python source files under `package_manager` as Python 3 code. `decode('utf-8')` is unnecessary in Python 3: https://stackoverflow.com/a/28583969/1701388. Initially I tried `srcs_version = "PY2ONLY"` for `py_library`, but Bazel said Python 2 and 3 are mixed in source.