### PR TITLE
Bazel 0.28 fixes

### DIFF
--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -1,5 +1,8 @@
-load(":dpkg.bzl", "dpkg_list", "dpkg_src")
+load(":dpkg.bzl", _dpkg_list = "dpkg_list", _dpkg_src = "dpkg_src")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+dpkg_list = _dpkg_list
+dpkg_src = _dpkg_src
 
 def package_manager_repositories():
   http_file(


### PR DESCRIPTION
Symbols loaded by load() are no longer visible externally, so they need to be re-exported
with an assignment.