### PR TITLE
Upgrade node image to latest LTS v10

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -171,10 +171,10 @@ http_archive(
 http_archive(
     name = "nodejs",
     build_file = "//experimental/nodejs:BUILD.nodejs",
-    sha256 = "dc004e5c0f39c6534232a73100c194bc1446f25e3a6a39b29e2000bb3d139d52",
-    strip_prefix = "node-v8.15.0-linux-x64/",
+    sha256 = "2f0397bb81c1d0c9901b9aff82a933257bf60f3992227b86107111a75b9030d9",
+    strip_prefix = "node-v10.16.3-linux-x64/",
     type = "tar.gz",
-    urls = ["https://nodejs.org/dist/v8.15.0/node-v8.15.0-linux-x64.tar.gz"],
+    urls = ["https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-x64.tar.gz"],
 )
 
 # dotnet

--- a/examples/nodejs/Dockerfile
+++ b/examples/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.15.0 AS build-env
+FROM node:10.16.3 AS build-env
 ADD . /app
 WORKDIR /app
 

--- a/experimental/nodejs/README.md
+++ b/experimental/nodejs/README.md
@@ -6,7 +6,7 @@ This image contains a minimal Linux, Node.js-based runtime.
 
 Specifically, the image contains everything in the [base image](../../base/README.md), plus:
 
-* Node.js v8.15.0 and its dependencies.
+- Node.js v10.16.3 and its dependencies.
 
 ## Usage
 


### PR DESCRIPTION
Node v8 has moved to maintenance LTS and v10 has moved to active LTS. Version `10.16.3` is now the latest active LTS version of Node js.

> It was [released](https://nodejs.org/download/release/latest-v10.x/) on the 15th of August. View the list of [deprecations](https://nodejs.org/en/blog/release/v10.0.0/#deprecations) from node 8 to node 10. 