### PR TITLE
buildifier.sh: Format .bzl files as well as BUILD and WORKSPACE

### DIFF
--- a/buildifier.sh
+++ b/buildifier.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-buildifier -mode=diff -diff_command='diff -u' $(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)
+buildifier -mode=diff -diff_command='diff -u' $(find . -name 'BUILD*' -o -name 'WORKSPACE*' -o -name '*.bzl' -type f)
 if [ $? -ne 0 ]; then
-  echo "Run 'buildifier -mode=fix \$(find . -name 'BUILD*' -o -name 'WORKSPACE*' -type f)' to fix formatting"
+  echo "Run 'buildifier -mode=fix \$(find . -name 'BUILD*' -o -name 'WORKSPACE*' -o -name '*.bzl' -type f)' to fix formatting"
   exit 1
 fi

--- a/cacerts/cacerts.bzl
+++ b/cacerts/cacerts.bzl
@@ -6,7 +6,7 @@ def _impl(ctx):
         arguments = [
             ctx.file.deb.path,
             ctx.outputs.tar.path,
-            ctx.outputs.deb.path
+            ctx.outputs.deb.path,
         ],
         inputs = [ctx.file.deb],
         outputs = [ctx.outputs.tar, ctx.outputs.deb],
@@ -33,4 +33,3 @@ cacerts = rule(
     },
     implementation = _impl,
 )
-

--- a/cacerts/java.bzl
+++ b/cacerts/java.bzl
@@ -16,10 +16,13 @@
 
 def _impl(ctx):
     # Strip off the '.tar'
-    image_name = ctx.attr._builder_image.label.name.split('.', 1)[0]
+    image_name = ctx.attr._builder_image.label.name.split(".", 1)[0]
+
     # container_image rules always generate an image named 'bazel/$package:$name'.
-    builder_image_name = "bazel/%s:%s" % (ctx.attr._builder_image.label.package,
-                                          image_name)
+    builder_image_name = "bazel/%s:%s" % (
+        ctx.attr._builder_image.label.package,
+        image_name,
+    )
 
     # Generate a shell script to run the build.
     build_contents = """\
@@ -38,20 +41,22 @@ tar -cf {2} etc/
 
 # Cleanup
 docker rm $cid
- """.format(ctx.file._builder_image.path,
-            builder_image_name,
-            ctx.outputs.out.path)
+ """.format(
+        ctx.file._builder_image.path,
+        builder_image_name,
+        ctx.outputs.out.path,
+    )
     script = ctx.actions.declare_file("cacerts.build")
     ctx.actions.write(
-        output=script,
-        content=build_contents,
+        output = script,
+        content = build_contents,
     )
 
     ctx.actions.run(
-        outputs=[ctx.outputs.out],
-        inputs=ctx.attr._builder_image.files.to_list() +
-        ctx.attr._builder_image.data_runfiles.files.to_list() + ctx.attr._builder_image.default_runfiles.files.to_list(),
-        executable=script,
+        outputs = [ctx.outputs.out],
+        inputs = ctx.attr._builder_image.files.to_list() +
+                 ctx.attr._builder_image.data_runfiles.files.to_list() + ctx.attr._builder_image.default_runfiles.files.to_list(),
+        executable = script,
     )
 
     return struct()

--- a/java/jre_ver.bzl
+++ b/java/jre_ver.bzl
@@ -1,9 +1,11 @@
 def jre_ver(version):
-  """Extract JRE version from a Debian openjdk package.
-    Debian packages versions are of the form:
-       openjdk-8-jre*: 8u171-b11-1~deb9u1
-       openjdk-11-jre*: 11.0.1+13-2~bpo9+1
-  """
-  if version.startswith("8u"): return version.split("-")[0]
-  if version.startswith("11."): return version.split("+")[0]
-  fail("unrecognized openjdk package version: " + version)
+    """Extract JRE version from a Debian openjdk package.
+      Debian packages versions are of the form:
+         openjdk-8-jre*: 8u171-b11-1~deb9u1
+         openjdk-11-jre*: 11.0.1+13-2~bpo9+1
+    """
+    if version.startswith("8u"):
+        return version.split("-")[0]
+    if version.startswith("11."):
+        return version.split("+")[0]
+    fail("unrecognized openjdk package version: " + version)

--- a/package_manager/dpkg.bzl
+++ b/package_manager/dpkg.bzl
@@ -1,20 +1,23 @@
 def _dpkg_list_impl(repository_ctx):
-  repository_ctx.file("file/BUILD", """
+    repository_ctx.file("file/BUILD", """
 package(default_visibility = ["//visibility:public"])
 deb_files = glob(["*.deb"])
 exports_files(deb_files + ["packages.bzl"])
 """)
 
-  args = [
-      repository_ctx.path(repository_ctx.attr._dpkg_parser),
-      "--package-files", ",".join([str(repository_ctx.path(src_path)) for src_path in repository_ctx.attr.sources]),
-      "--packages", ",".join(repository_ctx.attr.packages),
-      "--workspace-name", repository_ctx.name,
-  ]
+    args = [
+        repository_ctx.path(repository_ctx.attr._dpkg_parser),
+        "--package-files",
+        ",".join([str(repository_ctx.path(src_path)) for src_path in repository_ctx.attr.sources]),
+        "--packages",
+        ",".join(repository_ctx.attr.packages),
+        "--workspace-name",
+        repository_ctx.name,
+    ]
 
-  result = repository_ctx.execute(args)
-  if result.return_code:
-    fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join([str(a) for a in args])))
+    result = repository_ctx.execute(args)
+    if result.return_code:
+        fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join([str(a) for a in args])))
 
 _dpkg_list = repository_rule(
     _dpkg_list_impl,
@@ -32,25 +35,25 @@ _dpkg_list = repository_rule(
 )
 
 def _dpkg_src_impl(repository_ctx):
-  repository_ctx.file("file/BUILD", """
+    repository_ctx.file("file/BUILD", """
 package(default_visibility = ["//visibility:public"])
 exports_files(["Packages.json", "os_release.tar"])
 """)
-  args = [
-      repository_ctx.path(repository_ctx.attr._dpkg_parser),
-      "--download-and-extract-only=True",
-      "--mirror-url=" + repository_ctx.attr.url,
-      "--arch=" + repository_ctx.attr.arch,
-      "--distro=" + repository_ctx.attr.distro,
-      "--snapshot=" + repository_ctx.attr.snapshot,
-      "--packages-gz-url=" + repository_ctx.attr.packages_gz_url,
-      "--package-prefix=" + repository_ctx.attr.package_prefix,
-      "--sha256=" + repository_ctx.attr.sha256,
-  ]
+    args = [
+        repository_ctx.path(repository_ctx.attr._dpkg_parser),
+        "--download-and-extract-only=True",
+        "--mirror-url=" + repository_ctx.attr.url,
+        "--arch=" + repository_ctx.attr.arch,
+        "--distro=" + repository_ctx.attr.distro,
+        "--snapshot=" + repository_ctx.attr.snapshot,
+        "--packages-gz-url=" + repository_ctx.attr.packages_gz_url,
+        "--package-prefix=" + repository_ctx.attr.package_prefix,
+        "--sha256=" + repository_ctx.attr.sha256,
+    ]
 
-  result = repository_ctx.execute(args)
-  if result.return_code:
-    fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join([str(a) for a in args])))
+    result = repository_ctx.execute(args)
+    if result.return_code:
+        fail("dpkg_parser command failed: %s (%s)" % (result.stderr, " ".join([str(a) for a in args])))
 
 _dpkg_src = repository_rule(
     _dpkg_src_impl,
@@ -71,7 +74,7 @@ _dpkg_src = repository_rule(
 )
 
 def dpkg_list(**kwargs):
-  _dpkg_list(**kwargs)
+    _dpkg_list(**kwargs)
 
 def dpkg_src(**kwargs):
-  _dpkg_src(**kwargs)
+    _dpkg_src(**kwargs)

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -5,9 +5,9 @@ dpkg_list = _dpkg_list
 dpkg_src = _dpkg_src
 
 def package_manager_repositories():
-  http_file(
-      name = "dpkg_parser",
-      urls = [('https://storage.googleapis.com/distroless/package_manager_tools/548be30ea343ebf1e3729e1334b8adca8957e0c1/dpkg_parser.par')],
-      executable = True,
-      sha256 = "2ca62e67ce4d79a3f4072908559beef9f9c15e1a0f8dbc72a92c046f7c0c9df6",
-  )
+    http_file(
+        name = "dpkg_parser",
+        urls = [("https://storage.googleapis.com/distroless/package_manager_tools/548be30ea343ebf1e3729e1334b8adca8957e0c1/dpkg_parser.par")],
+        executable = True,
+        sha256 = "2ca62e67ce4d79a3f4072908559beef9f9c15e1a0f8dbc72a92c046f7c0c9df6",
+    )


### PR DESCRIPTION
Enforce auto-formatting on all Starlark files.

I noticed that the existing .bzl files were not auto-formatted while I was editing one of them. I'm assuming this is probably not intentional? Changing the .sh file causes the TravisCI build to break, so this will enforce this for future changes. See the failed build for the version that changed `buildifer.sh` but did not apply formatting: https://travis-ci.org/GoogleContainerTools/distroless/builds/576462638