### PR TITLE
debian10 support: Support Python2.7; Fix Python3; -debian9 suffix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -100,9 +100,10 @@ dpkg_list(
         "libc-bin=2.24-11+deb9u4",
 
         #python3
+        "libmpdec2",
         "libpython3.5-minimal",
-        "python3.5-minimal",
         "libpython3.5-stdlib",
+        "python3.5-minimal",
 
         #dotnet
         "libcurl3",
@@ -137,7 +138,6 @@ dpkg_list(
         "libffi6",
         "libtasn1-6",
         "libsasl2-modules-db",
-        "libdb5.3",
         "libgcrypt20",
         "libgpg-error0",
         "libacl1",
@@ -264,11 +264,9 @@ dpkg_list(
         "libbz2-1.0",
         "libdb5.3",
         "libffi6",
-        "libncursesw5",
         "liblzma5",
         "libexpat1",
         "libreadline7",
-        "libtinfo5",
         "libsqlite3-0",
         "mime-support",
         "netbase",
@@ -293,18 +291,20 @@ dpkg_list(
         # "openjdk-11-jre-headless",
 
         #python
-        # "libpython2.7-minimal",
-        # "python2.7-minimal",
-        # "libpython2.7-stdlib",
         "dash",
-        # Version required to skip a security fix to the pre-release library
-        # TODO: Remove when there is a security fix or dpkg_list finds the recent version
         "libc-bin",
+        "libpython2.7-minimal",
+        "libpython2.7-stdlib",
+        "python2.7-minimal",
 
         #python3
+        "libmpdec2",
         "libpython3.7-minimal",
-        "python3.7-minimal",
         "libpython3.7-stdlib",
+        "libtinfo6",
+        "libuuid1",
+        "libncursesw6",
+        "python3.7-minimal",
 
         #dotnet
         # "libcurl3",
@@ -339,7 +339,6 @@ dpkg_list(
         # "libffi6",
         # "libtasn1-6",
         # "libsasl2-modules-db",
-        # "libdb5.3",
         # "libgcrypt20",
         # "libgpg-error0",
         # "libacl1",

--- a/base/BUILD
+++ b/base/BUILD
@@ -113,9 +113,40 @@ go_binary(
 )
 
 # Replicate the containers and tests for debian9 and debian10
-distro_components("")  # debian9
+distro_components("-debian9")
 
 distro_components("-debian10")
+
+# alias debian9 as the default images
+alias(
+    name = "static",
+    actual = ":static-debian9",
+)
+
+alias(
+    name = "static-nonroot",
+    actual = ":static-nonroot-debian9",
+)
+
+alias(
+    name = "base",
+    actual = ":base-debian9",
+)
+
+alias(
+    name = "base-nonroot",
+    actual = ":base-nonroot-debian9",
+)
+
+alias(
+    name = "debug",
+    actual = ":debug-debian9",
+)
+
+alias(
+    name = "debug-nonroot",
+    actual = ":debug-nonroot-debian9",
+)
 
 container_test(
     name = "base_release_test-debian9",

--- a/base/base.bzl
+++ b/base/base.bzl
@@ -8,12 +8,12 @@ load("//cacerts:cacerts.bzl", "cacerts")
 NONROOT = 65532
 
 DISTRO_PACKAGES = {
-    "": packages,
+    "-debian9": packages,
     "-debian10": packages_debian10,
 }
 
 DISTRO_REPOSITORY = {
-    "": "@debian_stretch",
+    "-debian9": "@debian_stretch",
     "-debian10": "@debian10",
 }
 

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -5,7 +5,7 @@ load("@package_bundle//file:packages.bzl", "packages")
 load("@package_bundle_debian10//file:packages.bzl", packages_debian10 = "packages")
 
 DISTRO_PACKAGES = {
-    "": packages,
+    "-debian9": packages,
     "-debian10": packages_debian10,
 }
 
@@ -21,4 +21,15 @@ DISTRO_PACKAGES = {
 ) for mode in [
     "",
     ":debug",
-]] for distro_suffix in ("", "-debian10")]
+]] for distro_suffix in ("-debian9", "-debian10")]
+
+# Provide aliases so the default images use debian9
+alias(
+    name = "cc",
+    actual = ":cc-debian9",
+)
+
+alias(
+    name = "debug",
+    actual = ":debug-debian9",
+)

--- a/experimental/python2.7/BUILD
+++ b/experimental/python2.7/BUILD
@@ -3,30 +3,46 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@package_bundle//file:packages.bzl", "packages")
+load("@package_bundle_debian10//file:packages.bzl", packages_debian10 = "packages")
+
+DISTRO_PACKAGES = {
+    "-debian9": packages,
+    "-debian10": packages_debian10,
+}
+
+# distribution-specific deb dependencies
+DISTRO_DEBS = {
+    "-debian9": [
+        "libncursesw5",
+        "libtinfo5",
+    ],
+    "-debian10": [
+        "libncursesw6",
+        "libtinfo6",
+    ],
+}
 
 [container_image(
-    name = "python27" if (not mode) else mode[1:],
+    name = ("python27" if (not mode) else mode[1:]) + distro_suffix,
     # Based on //cc so that C extensions work properly.
-    base = "//cc" + mode,
+    base = "//cc" + (mode if mode else ":cc") + distro_suffix,
     debs = [
-        packages["dash"],
-        packages["libbz2-1.0"],
-        packages["libc-bin"],
-        packages["libexpat1"],
-        packages["libdb5.3"],
-        packages["libffi6"],
-        packages["libncursesw5"],
-        packages["libreadline7"],
-        packages["libsqlite3-0"],
-        packages["libssl1.1"],
-        packages["libtinfo5"],
-        packages["mime-support"],
-        packages["readline-common"],
-        packages["zlib1g"],
-        packages["python2.7-minimal"],
-        packages["libpython2.7-minimal"],
-        packages["libpython2.7-stdlib"],
-    ],
+        DISTRO_PACKAGES[distro_suffix]["dash"],
+        DISTRO_PACKAGES[distro_suffix]["libbz2-1.0"],
+        DISTRO_PACKAGES[distro_suffix]["libc-bin"],
+        DISTRO_PACKAGES[distro_suffix]["libexpat1"],
+        DISTRO_PACKAGES[distro_suffix]["libdb5.3"],
+        DISTRO_PACKAGES[distro_suffix]["libffi6"],
+        DISTRO_PACKAGES[distro_suffix]["libreadline7"],
+        DISTRO_PACKAGES[distro_suffix]["libsqlite3-0"],
+        DISTRO_PACKAGES[distro_suffix]["libssl1.1"],
+        DISTRO_PACKAGES[distro_suffix]["mime-support"],
+        DISTRO_PACKAGES[distro_suffix]["readline-common"],
+        DISTRO_PACKAGES[distro_suffix]["zlib1g"],
+        DISTRO_PACKAGES[distro_suffix]["python2.7-minimal"],
+        DISTRO_PACKAGES[distro_suffix]["libpython2.7-minimal"],
+        DISTRO_PACKAGES[distro_suffix]["libpython2.7-stdlib"],
+    ] + [DISTRO_PACKAGES[distro_suffix][deb] for deb in DISTRO_DEBS[distro_suffix]],
     entrypoint = [
         "/usr/bin/python2.7",
     ],
@@ -39,12 +55,27 @@ load("@package_bundle//file:packages.bzl", "packages")
 ) for mode in [
     "",
     ":debug",
-]]
+] for distro_suffix in ("-debian9", "-debian10")]
+
+[container_test(
+    name = "python27" + distro_suffix + "_test",
+    configs = ["testdata/python27.yaml"],
+    image = ":python27" + distro_suffix,
+) for distro_suffix in ("-debian9", "-debian10")]
+
+# tests for version-specific things
+container_test(
+    name = "debian9_test",
+    size = "medium",
+    configs = ["testdata/debian9.yaml"],
+    image = ":python27-debian9",
+)
 
 container_test(
-    name = "python27_test",
-    configs = ["testdata/python27.yaml"],
-    image = ":python27",
+    name = "debian10_test",
+    size = "medium",
+    configs = ["testdata/debian10.yaml"],
+    image = ":python27-debian10",
 )
 
 genrule(
@@ -58,11 +89,12 @@ genrule(
 sh_binary(
     name = "generate_ldconfig_cache",
     srcs = ["generate_ldconfig_cache.py"],
-    data = [":python27"],
+    data = [":python27-debian9"],
 )
 
 genrule(
     name = "ld_so_cache_new",
+    srcs = [":python27-debian9"],
     outs = ["ld.so.cache.new"],
     cmd = "$(location :generate_ldconfig_cache) $(OUTS)",
     tools = [":generate_ldconfig_cache"],
@@ -79,4 +111,15 @@ sh_test(
         ":ld.so.cache",
         ":ld.so.cache.new",
     ],
+)
+
+# Provide aliases so the default images use debian9
+alias(
+    name = "python27",
+    actual = ":python27-debian9",
+)
+
+alias(
+    name = "debug",
+    actual = ":debug-debian9",
 )

--- a/experimental/python2.7/generate_ldconfig_cache.py
+++ b/experimental/python2.7/generate_ldconfig_cache.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 
 
-CONTAINER_IMAGE_PATH = 'experimental/python2.7/python27'
+CONTAINER_IMAGE_PATH = 'experimental/python2.7/python27-debian9'
 
 
 def main():

--- a/experimental/python2.7/testdata/debian10.yaml
+++ b/experimental/python2.7/testdata/debian10.yaml
@@ -1,0 +1,5 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: version
+    command: ["/usr/bin/python2.7", "--version"]
+    expectedError: ["Python 2.7.16"]

--- a/experimental/python2.7/testdata/debian9.yaml
+++ b/experimental/python2.7/testdata/debian9.yaml
@@ -1,0 +1,5 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: version
+    command: ["/usr/bin/python2.7", "--version"]
+    expectedError: ["Python 2.7.13"]

--- a/experimental/python2.7/testdata/python27.yaml
+++ b/experimental/python2.7/testdata/python27.yaml
@@ -3,9 +3,6 @@ commandTests:
   - name: hello
     command: ["/usr/bin/python2.7", "-c", "print 'Hello World'"]
     expectedOutput: ['Hello World']
-  - name: version
-    command: ["/usr/bin/python2.7", "--version"]
-    expectedError: ["Python 2.7.13"]
   # parts of the standard library assume /bin/sh exists via os.system and subprocess.Popen
   - name: use_shell
     command: ["/usr/bin/python2.7", "-c",

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -6,30 +6,32 @@ load("@package_bundle//file:packages.bzl", "packages")
 load("@package_bundle_debian10//file:packages.bzl", packages_debian10 = "packages")
 
 DISTRO_PACKAGES = {
-    "": packages,
+    "-debian9": packages,
     "-debian10": packages_debian10,
 }
 
 # distribution-specific deb dependencies
 DISTRO_DEBS = {
-    "": [
-        # Different python packages have different transitive dependencies
-        # on the different libssl shared library versions.
-        "libssl1.0.2",
-        "python3.5-minimal",
+    "-debian9": [
+        "libncursesw5",
         "libpython3.5-minimal",
         "libpython3.5-stdlib",
+        "libtinfo5",
+        "python3.5-minimal",
     ],
     "-debian10": [
-        "python3.7-minimal",
+        "libffi6",
+        "libncursesw6",
         "libpython3.7-minimal",
         "libpython3.7-stdlib",
-        "libffi6",
+        "libtinfo6",
+        "libuuid1",
+        "python3.7-minimal",
     ],
 }
 
 DISTRO_VERSION = {
-    "": "3.5",
+    "-debian9": "3.5",
     "-debian10": "3.7",
 }
 
@@ -39,16 +41,16 @@ DISTRO_VERSION = {
     base = "//cc" + (mode if mode else ":cc") + distro_suffix,
     debs = [
         DISTRO_PACKAGES[distro_suffix]["dash"],
-        DISTRO_PACKAGES[distro_suffix]["zlib1g"],
         DISTRO_PACKAGES[distro_suffix]["libbz2-1.0"],
         DISTRO_PACKAGES[distro_suffix]["libc-bin"],
-        DISTRO_PACKAGES[distro_suffix]["libncursesw5"],
+        DISTRO_PACKAGES[distro_suffix]["libdb5.3"],
+        DISTRO_PACKAGES[distro_suffix]["libexpat1"],
         DISTRO_PACKAGES[distro_suffix]["liblzma5"],
+        DISTRO_PACKAGES[distro_suffix]["libmpdec2"],
         DISTRO_PACKAGES[distro_suffix]["libreadline7"],
-        DISTRO_PACKAGES[distro_suffix]["libtinfo5"],
         DISTRO_PACKAGES[distro_suffix]["libsqlite3-0"],
         DISTRO_PACKAGES[distro_suffix]["libssl1.1"],
-        DISTRO_PACKAGES[distro_suffix]["libexpat1"],
+        DISTRO_PACKAGES[distro_suffix]["zlib1g"],
     ] + [DISTRO_PACKAGES[distro_suffix][deb] for deb in DISTRO_DEBS[distro_suffix]],
     entrypoint = [
         "/usr/bin/python" + DISTRO_VERSION[distro_suffix],
@@ -63,11 +65,37 @@ DISTRO_VERSION = {
 ) for mode in [
     "",
     ":debug",
-]] for distro_suffix in ("", "-debian10")]
+]] for distro_suffix in ("-debian9", "-debian10")]
 
-container_test(
-    name = "python3_test",
+[container_test(
+    name = "python3" + distro_suffix + "_test",
     size = "medium",
     configs = ["testdata/python3.yaml"],
-    image = ":python3",
+    image = ":python3" + distro_suffix,
+) for distro_suffix in ("-debian9", "-debian10")]
+
+# tests for version-specific things
+container_test(
+    name = "debian9_test",
+    size = "medium",
+    configs = ["testdata/debian9.yaml"],
+    image = ":python3-debian9",
+)
+
+container_test(
+    name = "debian10_test",
+    size = "medium",
+    configs = ["testdata/debian10.yaml"],
+    image = ":python3-debian10",
+)
+
+# Provide aliases so the default images use debian9
+alias(
+    name = "python3",
+    actual = ":python3-debian9",
+)
+
+alias(
+    name = "debug",
+    actual = ":debug-debian9",
 )

--- a/experimental/python3/testdata/debian10.yaml
+++ b/experimental/python3/testdata/debian10.yaml
@@ -1,0 +1,12 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: version
+    command: ["/usr/bin/python3", "--version"]
+    expectedOutput: ["Python 3.7.3"]
+  - name: symlink
+    command: ["/usr/bin/python", "--version"]
+    expectedOutput: ["Python 3.7.3"]
+  # Python3.7 depends on libuuid1, but the uuid module falls back to a slower mechanism
+  - name: import_native_uuid
+    command: ["/usr/bin/python3", "-c", "import _uuid"]
+    exitCode: 0

--- a/experimental/python3/testdata/debian9.yaml
+++ b/experimental/python3/testdata/debian9.yaml
@@ -1,0 +1,8 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: version
+    command: ["/usr/bin/python3", "--version"]
+    expectedOutput: ["Python 3.5.3"]
+  - name: symlink
+    command: ["/usr/bin/python", "--version"]
+    expectedOutput: ["Python 3.5.3"]

--- a/experimental/python3/testdata/python3.yaml
+++ b/experimental/python3/testdata/python3.yaml
@@ -3,15 +3,6 @@ commandTests:
   - name: hello
     command: ["/usr/bin/python3", "-c", "print('Hello World')"]
     expectedOutput: ['Hello World']
-  - name: version
-    command: ["/usr/bin/python3", "--version"]
-    expectedOutput: ["Python 3.5.3"]
-  - name: stdlib
-    command: ["/usr/bin/python3", "-c", "import argparse"]
-    exitCode: 0
-  - name: symlink 
-    command: ["/usr/bin/python", "--version"]
-    expectedOutput: ["Python 3.5.3"]
   # parts of the standard library assume /bin/sh exists via os.system and subprocess.Popen
   - name: use_shell
     command: ["/usr/bin/python3", "-c",
@@ -135,8 +126,14 @@ commandTests:
   - name: import_datetime
     command: ["/usr/bin/python3", "-c", "import datetime"]
     exitCode: 0
+  - name: import_native_dbm
+    command: ["/usr/bin/python3", "-c", "import _dbm"]
+    exitCode: 0
   - name: import_dbm
     command: ["/usr/bin/python3", "-c", "import dbm"]
+    exitCode: 0
+  - name: import_native_decimal
+    command: ["/usr/bin/python3", "-c", "import _decimal"]
     exitCode: 0
   - name: import_decimal
     command: ["/usr/bin/python3", "-c", "import decimal"]
@@ -152,9 +149,6 @@ commandTests:
     exitCode: 0
   - name: import_doctest
     command: ["/usr/bin/python3", "-c", "import doctest"]
-    exitCode: 0
-  - name: import_dummy_threading
-    command: ["/usr/bin/python3", "-c", "import dummy_threading"]
     exitCode: 0
   - name: import_email
     command: ["/usr/bin/python3", "-c", "import email"]
@@ -231,9 +225,6 @@ commandTests:
   - name: import_http
     command: ["/usr/bin/python3", "-c", "import http"]
     exitCode: 0
-  - name: import_idlelib
-    command: ["/usr/bin/python3", "-c", "import idlelib"]
-    exitCode: 0
   - name: import_imaplib
     command: ["/usr/bin/python3", "-c", "import imaplib"]
     exitCode: 0
@@ -264,9 +255,6 @@ commandTests:
   - name: import_keyword
     command: ["/usr/bin/python3", "-c", "import keyword"]
     exitCode: 0
-  - name: import_lib2to3
-    command: ["/usr/bin/python3", "-c", "import lib2to3"]
-    exitCode: 0
   - name: import_linecache
     command: ["/usr/bin/python3", "-c", "import linecache"]
     exitCode: 0
@@ -281,9 +269,6 @@ commandTests:
     exitCode: 0
   - name: import_macpath
     command: ["/usr/bin/python3", "-c", "import macpath"]
-    exitCode: 0
-  - name: import_macurl2path
-    command: ["/usr/bin/python3", "-c", "import macurl2path"]
     exitCode: 0
   - name: import_mailbox
     command: ["/usr/bin/python3", "-c", "import mailbox"]


### PR DESCRIPTION
This adds explicit -debian9 suffixes to the base, cc, and python
packages, with aliases for compatibility.

python2.7: Add support for -debian9 and -debian10

python3:
* add libmpdec2, libdb5.3: required by the standard library, and
  was previous missing. I think this is because the standard library
  modules include fallbacks in case the native modules are missing.
* add tests for native code _dbm, _decimal to ensure we use native libs
* remove tests for dummy_threading: deprecated and does not work on
  Debian 10
* remove test for idlelib: Not installed by default (requires
  idle-python3.7). This also needs X11, so doesn't seem to make sense.
* remove test for lib2to3 and macurl2path: does not exist in 3.7

Another part of adding Debian 10 support (Issue #385)