### PR TITLE
python: Set LANG=C.UTF-8; python2.7: PYTHONIOENCODING=UTF-8

### DIFF
--- a/experimental/python2.7/BUILD
+++ b/experimental/python2.7/BUILD
@@ -30,6 +30,11 @@ load("@package_bundle//file:packages.bzl", "packages")
     entrypoint = [
         "/usr/bin/python2.7",
     ],
+    # Use UTF-8 encoding for file system and stdout: match modern Linux
+    env = {
+        "LANG": "C.UTF-8",
+        "PYTHONIOENCODING": "UTF-8",
+    },
     symlinks = {
         "/usr/bin/python": "/usr/bin/python2.7",
     },

--- a/experimental/python2.7/testdata/python27.yaml
+++ b/experimental/python2.7/testdata/python27.yaml
@@ -15,6 +15,17 @@ commandTests:
     command: ["/usr/bin/python2.7", "-c", "import ctypes.util; ctypes.CDLL(ctypes.util.find_library('rt')).timer_create"]
     exitCode: 0
 
+  # file names are UTF-8: default for modern Linux systems
+  # The \xe9 backslash must be double-escaped to avoid YAML string parsing weirdness
+  - name: filesystem_utf8
+    command: ["/usr/bin/python2.7", "-c", "open(u'h\\xe9llo.txt', 'w'); import sys; print(sys.getfilesystemencoding())"]
+    expectedOutput: ['UTF-8']
+
+  # the print function should output UTF-8
+  - name: print_utf8
+    command: ["/usr/bin/python2.7", "-c", "print(u'h\\xe9llo.txt')"]
+    expectedOutput: ['h\xe9llo']
+
   - name: import_BaseHTTPServer
     command: ["/usr/bin/python2.7", "-c", "import BaseHTTPServer"]
     exitCode: 0

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -53,6 +53,8 @@ DISTRO_VERSION = {
     entrypoint = [
         "/usr/bin/python" + DISTRO_VERSION[distro_suffix],
     ],
+    # Use UTF-8 encoding for file system: match modern Linux
+    env = {"LANG": "C.UTF-8"},
     symlinks = {
         "/usr/bin/python": "/usr/bin/python" + DISTRO_VERSION[distro_suffix],
         "/usr/bin/python3": "/usr/bin/python" + DISTRO_VERSION[distro_suffix],

--- a/experimental/python3/testdata/python3.yaml
+++ b/experimental/python3/testdata/python3.yaml
@@ -21,6 +21,17 @@ commandTests:
     command: ["/usr/bin/python3", "-c", "import ctypes.util; ctypes.CDLL(ctypes.util.find_library('rt')).timer_create"]
     exitCode: 0
 
+  # file names are UTF-8: default for modern Linux systems
+  # The \xe9 backslash must be double-escaped to avoid YAML string parsing weirdness
+  - name: filesystem_utf8
+    command: ["/usr/bin/python3", "-c", "open(u'h\\xe9llo', 'w'); import sys; print(sys.getfilesystemencoding())"]
+    expectedOutput: ['utf-8']
+
+  # the print function should output UTF-8
+  - name: print_utf8
+    command: ["/usr/bin/python3", "-c", "print(u'h\\xe9llo.txt')"]
+    expectedOutput: ['h\xe9llo']
+
   - name: import_abc
     command: ["/usr/bin/python3", "-c", "import abc"]
     exitCode: 0


### PR DESCRIPTION
By default modern Linux systems use UTF-8 for encoding file names,
although AFAICS that is controlled by the LANG environment variable
and some other things. However, Python programs that run on Debian or
Ubuntu may expect this to work. The upstream Docker Python image sets
these environment variables. We should as well. See:

https://github.com/docker-library/python/blob/35566cb6b14961c369e935b85b4c8879e6901ccc/2.7/buster/Dockerfile

* Add tests for file system encoding and the print() function.
* Set LANG=C.UTF-8 for both Python3 and Python2.7
* Set PYTHONIOENCODING=UTF-8 for Python2.7 (not neeeded on Python3)