### PR TITLE
Mention how to append the debug tag when an image has a tag already

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,5 +178,6 @@ $ docker run --entrypoint=sh -ti my_debug_image
 /app # ls
 BUILD       Dockerfile  hello.py
 ```
+> Note: If the image you are using already has a tag, for example `gcr.io/distroless/java:11`, use the tag `<existing tag>-debug` instead, for example `gcr.io/distroless/java:11-debug`.
 
 > Note: [ldd](http://man7.org/linux/man-pages/man1/ldd.1.html) is not installed in the base image as it's a shell script, you can copy it in or download it.


### PR DESCRIPTION
Hi Distroless, 

Thanks for documenting the `:debug` option to allow troubleshooting with a shell, very helpful. It wasn't very obvious to me from the README.me how to apply the debug tag to an image that already has a tag, like `gcr.io/distroless/java:11`. 

I thought adding a dash would help and it worked, but I'm not sure if this is the recommended way to do this. Opening this PR to start some discussion.