### PR TITLE
package_manager.bzl: Use newest version to support Debian 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jdk:
 install:
   - export PATH=$PATH:$HOME/bin && mkdir -p $HOME/bin
   - wget https://github.com/bazelbuild/buildtools/releases/download/0.22.0/buildifier && chmod +x buildifier && mv buildifier $HOME/bin/
-  - wget https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-linux-x86_64 && mv bazel-0.28.1-linux-x86_64 bazel && chmod +x bazel && mv bazel $HOME/bin/
+  - wget https://github.com/bazelbuild/bazel/releases/download/1.0.0/bazel-1.0.0-linux-x86_64 && mv bazel-1.0.0-linux-x86_64 bazel && chmod +x bazel && mv bazel $HOME/bin/
   - sudo pip install pylint
 
 script:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -197,9 +197,9 @@ http_file(
 # Docker rules.
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "87fc6a2b128147a0a3039a2fd0b53cc1f2ed5adb8716f50756544a572999ae9a",
-    strip_prefix = "rules_docker-0.8.1",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.8.1.tar.gz"],
+    sha256 = "413bb1ec0895a8d3249a01edf24b82fd06af3c8633c9fb833a0cb1d4b234d46d",
+    strip_prefix = "rules_docker-0.12.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.12.0.tar.gz"],
 )
 
 load(

--- a/base/testdata/debian10.yaml
+++ b/base/testdata/debian10.yaml
@@ -2,6 +2,4 @@ schemaVersion: "1.0.0"
 fileContentTests:
 - name: 'os-release contents'
   path: '/etc/os-release'
-  # TODO: Update with newer release of dpkg_parser.par in package_manager.bzl
-  #expectedContents: ['.*\nVERSION="Debian GNU/Linux 10 (buster)"\n']
-  excludedContents: ['.*\nVERSION=']
+  expectedContents: ['.*\nVERSION="Debian GNU/Linux 10 \(buster\)"\n']

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -7,7 +7,7 @@ dpkg_src = _dpkg_src
 def package_manager_repositories():
     http_file(
         name = "dpkg_parser",
-        urls = [("https://storage.googleapis.com/distroless/package_manager_tools/548be30ea343ebf1e3729e1334b8adca8957e0c1/dpkg_parser.par")],
+        urls = [("https://storage.googleapis.com/distroless/package_manager_tools/0e7095cc1ac3e084a1d76f86c36f8ec38483eb24/dpkg_parser.par")],
         executable = True,
-        sha256 = "2ca62e67ce4d79a3f4072908559beef9f9c15e1a0f8dbc72a92c046f7c0c9df6",
+        sha256 = "4511b371e181d9b2b8479c180a751c1975a1ca7d329f7b6353d48c099a779c5a",
     )


### PR DESCRIPTION
Corrects the VERSION variable in /etc/os-release

Commit c127f3e5f3 added support for Debian 10 (buster) to
package_manager. Due to the way WORKSPACE dependencies work, we
need this update to actually use the new version.

I also needed to update the version of rules_docker to avoid a Python3
error. This could be because I'm using the latest version of bazel,
but seems like a good idea also.