### PR TITLE
base: Make -debian10 images default to nonroot user

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -9,7 +9,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 NOBODY = 65534
 
-# Create /etc/passwd with the root user
+# Create /etc/passwd with root, nobody, and nonroot users
 passwd_entry(
     name = "root_user",
     gid = 0,

--- a/base/base.bzl
+++ b/base/base.bzl
@@ -17,6 +17,18 @@ DISTRO_REPOSITORY = {
     "-debian10": "@debian10",
 }
 
+# debian9 defaults to root for backwards compatibility
+# debian10 defaults to nonroot for security (e.g. the runc escape CVE-2019-5736)
+DISTRO_USERS = {
+    "-debian9": 0,
+    "-debian10": NONROOT,
+}
+
+DISTRO_WORKDIRS = {
+    "-debian9": "/",
+    "-debian10": "/home/nonroot",
+}
+
 # Replicate everything for debian9 and debian10
 def distro_components(distro_suffix):
     cacerts(
@@ -51,6 +63,8 @@ def distro_components(distro_suffix):
             DISTRO_REPOSITORY[distro_suffix] + "//file:os_release.tar",
             ":cacerts" + distro_suffix + ".tar",
         ],
+        user = "%d" % DISTRO_USERS[distro_suffix],
+        workdir = DISTRO_WORKDIRS[distro_suffix],
     )
 
     container_image(


### PR DESCRIPTION
Fixes #374.

Running as a non-root user inside a container provides some additional
security. For example, the runc container escape would not work for
non-root users:

https://aws.amazon.com/blogs/compute/anatomy-of-cve-2019-5736-a-runc-container-escape/

The existing Distroless images need to default to a root user for
compatibility. However, the introduction of -debian10 images gives us
an opportunity to break backwards compatibility, since users will need
to opt-in to the update anyway.