### PR TITLE
Upgrade Node.js to latest v10 LTS

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -171,10 +171,10 @@ http_archive(
 http_archive(
     name = "nodejs",
     build_file = "//experimental/nodejs:BUILD.nodejs",
-    sha256 = "2f0397bb81c1d0c9901b9aff82a933257bf60f3992227b86107111a75b9030d9",
-    strip_prefix = "node-v10.16.3-linux-x64/",
+    sha256 = "417bdc5402f6510fe1a5a898a9cdf1d67bd0202b5f014051c382f05358999534",
+    strip_prefix = "node-v10.17.0-linux-x64/",
     type = "tar.gz",
-    urls = ["https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-x64.tar.gz"],
+    urls = ["https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-x64.tar.gz"],
 )
 
 # dotnet

--- a/examples/nodejs/Dockerfile
+++ b/examples/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.16.3 AS build-env
+FROM node:10.17.0 AS build-env
 ADD . /app
 WORKDIR /app
 

--- a/examples/nodejs/node-express/Dockerfile
+++ b/examples/nodejs/node-express/Dockerfile
@@ -1,6 +1,7 @@
-FROM node:8.15.0 AS build-env
+FROM node:10.17.0 AS build-env
 ADD . /app
 WORKDIR /app
+RUN npm install --production
 
 FROM gcr.io/distroless/nodejs
 COPY --from=build-env /app /app

--- a/examples/nodejs/node-express/package.json
+++ b/examples/nodejs/node-express/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "Distroless express",
+  "name": "distroless-express",
   "version": "1.0.0",
   "description": "Distroless express node.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleContainerTools/distroless.git"
+  },
   "dependencies": {
     "express": "4.16.3"
   },


### PR DESCRIPTION
[v10.17.0 Release Notes](https://nodejs.org/en/blog/release/v10.17.0/)

#### Fixes
 - Invalid npm package name for Express example
 - Missing `npm install` step
 - Aligns Node build environment version with Distroless