### PR TITLE
python3-requirements: Example that uses third-party dependencies

### DIFF
--- a/examples/python3-requirements/Dockerfile
+++ b/examples/python3-requirements/Dockerfile
@@ -1,0 +1,21 @@
+# Build a virtualenv using the appropriate Debian release
+# * Install python3-venv for the built-in Python3 venv module (not installed by default)
+# * Install gcc libpython3-dev to compile C Python modules
+# * Update pip to support bdist_wheel
+FROM debian:buster-slim AS build
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
+    python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip
+
+# Build the virtualenv as a separate step: Only re-execute this step when requirements.txt changes
+FROM build AS build-venv
+COPY requirements.txt /requirements.txt
+RUN /venv/bin/pip install --disable-pip-version-check -r /requirements.txt
+
+# Copy the virtualenv into a distroless image
+FROM gcr.io/distroless/python3-debian10
+COPY --from=build-venv /venv /venv
+COPY . /app
+WORKDIR /app
+ENTRYPOINT ["/venv/bin/python3", "psutil_example.py"]

--- a/examples/python3-requirements/README.md
+++ b/examples/python3-requirements/README.md
@@ -1,0 +1,34 @@
+# Python 3 with requirements.txt
+
+This is a Python 3 application that specifies third-party dependencies using requirements.txt. The
+psutil module it uses is a C module that must be compiled. This is the most annoying kind of
+dependency, since you need to build it in an environment where the C library and Python version
+match where it will run.
+
+It builds the final container in three stages:
+
+1. `build`: Set up a Debian build environment that can compile Python C modules.
+2. `build-venv`: Create a virtualenv using `requirements.txt`.
+3. Output: Copy the venv and the code and build the final image.
+
+The first step is only re-executed if you edit `Dockerfile`. The second step is only re-executed
+if you change requirements.txt. The final step is very fast and will change on every code edit.
+
+
+## Build and run
+
+1. Build the image: `docker build . --tag=psutil-example`
+2. Run it! `docker run --rm psutil-example`
+
+
+## Example output
+
+```
+RSS: 13.0 MiB;  SHARED: 5.7 MiB; VIRTUAL: 19.9 MiB
+```
+
+
+## TODO: Bazel
+
+It would be nice if we could show how to build this container with Bazel, but I don't actually know
+how to do that.

--- a/examples/python3-requirements/psutil_example.py
+++ b/examples/python3-requirements/psutil_example.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Distroless's test.sh runs pylint on all python files, but this module will not exist
+# pylint: disable=import-error
+import psutil
+
+
+def mib(total_bytes):
+    '''Converts bytes to MiB (float).'''
+    return total_bytes / 1024 / 1024
+
+
+def main():
+    current_process = psutil.Process()
+    memory = current_process.memory_info()
+    print('RSS: {:.1f} MiB;  SHARED: {:.1f} MiB; VIRTUAL: {:.1f} MiB'.format(
+        mib(memory.rss), mib(memory.shared), mib(memory.vms)))
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/python3-requirements/requirements.txt
+++ b/examples/python3-requirements/requirements.txt
@@ -1,0 +1,2 @@
+# this version of psutil does not ship binary wheels: must be compiled
+psutil==5.6.3


### PR DESCRIPTION
This does not build with Bazel, so it is not currently covered by the
TravisCI test.