### PR TITLE
Include JVM instrumentation binaries in the distroless/java debug image.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,7 +88,9 @@ dpkg_list(
         "fontconfig-config",
         "libfontconfig1",
         "openjdk-8-jre-headless",
+        "openjdk-8-jdk-headless",
         "openjdk-11-jre-headless",
+        "openjdk-11-jdk-headless",
 
         #python
         "libpython2.7-minimal",
@@ -288,6 +290,7 @@ dpkg_list(
         "fontconfig-config",
         "libfontconfig1",
         "openjdk-11-jre-headless",
+        "openjdk-11-jdk-headless",
 
         #python
         "dash",

--- a/java/BUILD
+++ b/java/BUILD
@@ -37,8 +37,7 @@ cacerts_java(
         DISTRO_PACKAGES[distro_suffix]["fontconfig-config"],
         DISTRO_PACKAGES[distro_suffix]["libexpat1"],
         DISTRO_PACKAGES[distro_suffix]["libfontconfig1"],
-        DISTRO_PACKAGES[distro_suffix][jre_deb],
-    ],
+    ] + [DISTRO_PACKAGES[distro_suffix][deb] for deb in java_debs],
     # We expect users to use:
     # cmd = ["/path/to/deploy.jar", "--option1", ...]
     entrypoint = [
@@ -46,19 +45,58 @@ cacerts_java(
         "-jar",
     ],
     env = {
-        "JAVA_VERSION": jre_ver(DISTRO_VERSIONS[distro_suffix][jre_deb]),
+        "JAVA_VERSION": jre_ver(DISTRO_VERSIONS[distro_suffix][java_debs[0]]),
     },
     symlinks = {
         "/usr/bin/java": java_executable_path,
     },
     tars = [":cacerts_java"],
-) for (distro_suffix, rule_name, jre_deb, java_executable_path) in [
-    ("_debian9", "java8", "openjdk-8-jre-headless", "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"),
-    ("_debian9", "java8_debug", "openjdk-8-jre-headless", "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"),
-    ("_debian9", "java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"),
-    ("_debian9", "java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"),
-    ("_debian10", "java11", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"),
-    ("_debian10", "java11_debug", "openjdk-11-jre-headless", "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"),
+) for (distro_suffix, rule_name, java_debs, java_executable_path) in [
+    (
+        "_debian9",
+        "java8",
+        ["openjdk-8-jre-headless"],
+        "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
+    ),
+    (
+        "_debian9",
+        "java8_debug",
+        [
+            "openjdk-8-jre-headless",
+            "openjdk-8-jdk-headless",
+        ],
+        "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java",
+    ),
+    (
+        "_debian9",
+        "java11",
+        ["openjdk-11-jre-headless"],
+        "/usr/lib/jvm/java-11-openjdk-amd64/bin/java",
+    ),
+    (
+        "_debian9",
+        "java11_debug",
+        [
+            "openjdk-11-jre-headless",
+            "openjdk-11-jdk-headless",
+        ],
+        "/usr/lib/jvm/java-11-openjdk-amd64/bin/java",
+    ),
+    (
+        "_debian10",
+        "java11",
+        ["openjdk-11-jre-headless"],
+        "/usr/lib/jvm/java-11-openjdk-amd64/bin/java",
+    ),
+    (
+        "_debian10",
+        "java11_debug",
+        [
+            "openjdk-11-jre-headless",
+            "openjdk-11-jdk-headless",
+        ],
+        "/usr/lib/jvm/java-11-openjdk-amd64/bin/java",
+    ),
 ]]
 
 # Provide aliases so the default images use debian9

--- a/java/jetty/testdata/java11.yaml
+++ b/java/jetty/testdata/java11.yaml
@@ -22,3 +22,6 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+  - name: no-javac
+    path: "/usr/lib/jvm/java-11-openjdk-amd64/bin/javac"
+    shouldExist: false

--- a/java/jetty/testdata/java11_debug.yaml
+++ b/java/jetty/testdata/java11_debug.yaml
@@ -12,6 +12,10 @@ commandTests:
     command: "/usr/bin/java"
     args: ["-version"]
     expectedError: ['openjdk version "11\.*']
+  - name: javac
+    command: "/usr/lib/jvm/java-11-openjdk-amd64/bin/javac"
+    args: ["-version"]
+    expectedOutput: ['javac 11\.*']
 fileExistenceTests:
   - name: certs
     path: "/etc/ssl/certs/java/cacerts"

--- a/java/jetty/testdata/java8.yaml
+++ b/java/jetty/testdata/java8.yaml
@@ -22,3 +22,6 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+  - name: no-javac
+    path: "/usr/lib/jvm/java-8-openjdk-amd64/bin/javac"
+    shouldExist: false

--- a/java/jetty/testdata/java8_debug.yaml
+++ b/java/jetty/testdata/java8_debug.yaml
@@ -12,6 +12,10 @@ commandTests:
     command: "/usr/bin/java"
     args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
+  - name: javac
+    command: "/usr/lib/jvm/java-8-openjdk-amd64/bin/javac"
+    args: ["-version"]
+    expectedError: ['javac 1\.8.*']
 fileExistenceTests:
   - name: certs
     path: "/etc/ssl/certs/java/cacerts"

--- a/java/testdata/java11.yaml
+++ b/java/testdata/java11.yaml
@@ -18,6 +18,9 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+  - name: no-javac
+    path: "/usr/lib/jvm/java-11-openjdk-amd64/bin/javac"
+    shouldExist: false
 metadataTest:
   env:
     - key: 'JAVA_VERSION'

--- a/java/testdata/java11_debug.yaml
+++ b/java/testdata/java11_debug.yaml
@@ -8,6 +8,10 @@ commandTests:
     command: "/usr/bin/java"
     args: ["-version"]
     expectedError: ['openjdk version "11\.*']
+  - name: javac
+    command: "/usr/lib/jvm/java-11-openjdk-amd64/bin/javac"
+    args: ["-version"]
+    expectedOutput: ['javac 11\.*']
 fileExistenceTests:
   - name: certs
     path: "/etc/ssl/certs/java/cacerts"

--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -18,6 +18,9 @@ fileExistenceTests:
   - name: no-shell
     path: "/bin/sh"
     shouldExist: false
+  - name: no-javac
+    path: "/usr/lib/jvm/java-8-openjdk-amd64/bin/javac"
+    shouldExist: false
 metadataTest:
   entrypoint: ["/usr/bin/java", "-jar"]
   env:

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -8,6 +8,10 @@ commandTests:
     command: "/usr/bin/java"
     args: ["-version"]
     expectedError: ['openjdk version "1\.8.*"']
+  - name: javac
+    command: "/usr/lib/jvm/java-8-openjdk-amd64/bin/javac"
+    args: ["-version"]
+    expectedError: ['javac 1\.8.*']
 fileExistenceTests:
   - name: certs
     path: "/etc/ssl/certs/java/cacerts"


### PR DESCRIPTION
Closes #350.