### PR TITLE
python3 debian10: Install full version of distutils for virtualenv

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -306,6 +306,7 @@ dpkg_list(
         "libtinfo6",
         "libuuid1",
         "libncursesw6",
+        "python3-distutils",
         "python3.7-minimal",
 
         #dotnet

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -26,6 +26,7 @@ DISTRO_DEBS = {
         "libpython3.7-stdlib",
         "libtinfo6",
         "libuuid1",
+        "python3-distutils",
         "python3.7-minimal",
     ],
 }

--- a/experimental/python3/testdata/python3.yaml
+++ b/experimental/python3/testdata/python3.yaml
@@ -12,6 +12,12 @@ commandTests:
     command: ["/usr/bin/python3", "-c", "import ctypes.util; ctypes.CDLL(ctypes.util.find_library('rt')).timer_create"]
     exitCode: 0
 
+  # debian's default python3 includes a partial version of distutils causing virtualenv to fail
+  # ensure we have the full version so virtualenvs work with distroless
+  - name: distutils_works
+    command: ["/usr/bin/python3", "-c", "import distutils.dist"]
+    exitCode: 0
+
   # file names are UTF-8: default for modern Linux systems
   # The \xe9 backslash must be double-escaped to avoid YAML string parsing weirdness
   - name: filesystem_utf8


### PR DESCRIPTION
With Debian 10 buster, the python3 package only includes a partial
version of the distutils package. This causes virtualenv to create
a somewhat broken virtualenv, which causes the following import
error when attempting to use it. This fixes the error by installing
the full version from the standard library. Add a test to ensure
it continues to work.

Fixes the following error:

ImportError: cannot import name 'dist' from 'distutils'