### PR TITLE
Reduce visibility of package_manager

### DIFF
--- a/package_manager/BUILD
+++ b/package_manager/BUILD
@@ -4,7 +4,6 @@ par_binary(
     name = "dpkg_parser",
     srcs = glob(["**/*.py"]),
     main = "dpkg_parser.py",
-    visibility = ["//visibility:public"],
     deps = [
         ":parse_metadata",
         ":util",

--- a/package_manager/cloudbuild.yaml
+++ b/package_manager/cloudbuild.yaml
@@ -23,7 +23,7 @@ steps:
   args: [
     'cp',
     'bazel-bin/package_manager/dpkg_parser.par',
-    'gs://distroless/package_manager_tools/$COMMIT_SHA/dpkg_parser.par'
+    'gs://tmp-chanseok/package_manager_tools/$COMMIT_SHA/dpkg_parser.par'
   ]
 
 # We produce no Docker images.

--- a/package_manager/cloudbuild.yaml
+++ b/package_manager/cloudbuild.yaml
@@ -23,7 +23,7 @@ steps:
   args: [
     'cp',
     'bazel-bin/package_manager/dpkg_parser.par',
-    'gs://tmp-chanseok/package_manager_tools/$COMMIT_SHA/dpkg_parser.par'
+    'gs://distroless/package_manager_tools/$COMMIT_SHA/dpkg_parser.par'
   ]
 
 # We produce no Docker images.

--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -9,5 +9,5 @@ def package_manager_repositories():
         name = "dpkg_parser",
         urls = [("https://storage.googleapis.com/distroless/package_manager_tools/0e7095cc1ac3e084a1d76f86c36f8ec38483eb24/dpkg_parser.par")],
         executable = True,
-        sha256 = "4511b371e181d9b2b8479c180a751c1975a1ca7d329f7b6353d48c099a779c5a",
+        sha256 = "02aa2a062de01ce216fa795f470fe6bf2c90a7898c89df2941ab160c65119fc4",
     )


### PR DESCRIPTION
Turns out this is unnecessary.

I have confirmed building and publishing all images by
1. First building and uploading this PAR to a temporary bucket.
2. Updating WORKSPACE to use the new PAR, which required updating the SHA of the binary.
3. Build and publishing Distroless images on GCB (to my GCP project).