### PR TITLE
Use the newly built dpkg_parser binary

### DIFF
--- a/package_manager/package_manager.bzl
+++ b/package_manager/package_manager.bzl
@@ -7,7 +7,7 @@ dpkg_src = _dpkg_src
 def package_manager_repositories():
     http_file(
         name = "dpkg_parser",
-        urls = [("https://storage.googleapis.com/distroless/package_manager_tools/0e7095cc1ac3e084a1d76f86c36f8ec38483eb24/dpkg_parser.par")],
+        urls = [("https://storage.googleapis.com/distroless/package_manager_tools/1b8448ea6f55db64ea3c1956d4dd1b9c47166a8c/dpkg_parser.par")],
         executable = True,
         sha256 = "02aa2a062de01ce216fa795f470fe6bf2c90a7898c89df2941ab160c65119fc4",
     )


### PR DESCRIPTION
Because of the "two-step" build, when updating dpkg_parser, we can change the URL only after the binary with the change is built.

In #469, I uploaded the new binary too early (and replaced the old one, which was my mistake). So the following binaries have the same SHA, and there's no need to update SHA in this PR.

https://storage.googleapis.com/distroless/package_manager_tools/0e7095cc1ac3e084a1d76f86c36f8ec38483eb24/dpkg_parser.par
https://storage.googleapis.com/distroless/package_manager_tools/1b8448ea6f55db64ea3c1956d4dd1b9c47166a8c/dpkg_parser.par