### PR TITLE
Fix dpkg_parser.par Python3 shebang

### DIFF
--- a/package_manager/BUILD
+++ b/package_manager/BUILD
@@ -3,6 +3,10 @@ load("@subpar//:subpar.bzl", "par_binary")
 par_binary(
     name = "dpkg_parser",
     srcs = glob(["**/*.py"]),
+    compiler_args = [
+        "--interpreter",
+        "/usr/bin/env python",
+    ],
     main = "dpkg_parser.py",
     deps = [
         ":parse_metadata",


### PR DESCRIPTION
Fixes #434 (but only after merging #477). See https://github.com/GoogleContainerTools/distroless/pull/477#issuecomment-593132767.

This shebang idea has already been suggested by others (https://github.com/GoogleContainerTools/distroless/issues/434#issuecomment-570410807 and https://github.com/GoogleContainerTools/distroless/issues/434#issuecomment-584838725).