### PR TITLE
Add test for OS PRETTY_NAME

### DIFF
--- a/base/testdata/base.yaml
+++ b/base/testdata/base.yaml
@@ -41,3 +41,6 @@ fileContentTests:
 - name: 'known groups'
   path: '/etc/group'
   expectedContents: ['^root:x:0:\nnobody:x:65534:\ntty:x:5:\nstaff:x:50:\nnonroot:x:65532:\n$']
+- name: 'os-release pretty name'
+  path: '/etc/os-release'
+  expectedContents: ['^PRETTY_NAME="Distroless"$']

--- a/base/testdata/base.yaml
+++ b/base/testdata/base.yaml
@@ -43,4 +43,4 @@ fileContentTests:
   expectedContents: ['^root:x:0:\nnobody:x:65534:\ntty:x:5:\nstaff:x:50:\nnonroot:x:65532:\n$']
 - name: 'os-release pretty name'
   path: '/etc/os-release'
-  expectedContents: ['^PRETTY_NAME="Distroless"$']
+  expectedContents: ['PRETTY_NAME="Distroless"']


### PR DESCRIPTION
This is useful for reliably detecting base images, and if you like it you should put a test on it.