### PR TITLE
Build dpkg_parser.par in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,6 +10,8 @@ steps:
     #!/bin/sh
     set -o errexit
     set -o xtrace
+    bazel build --host_force_python=PY2 //package_manager:dpkg_parser.par
+
     bazel run --host_force_python=PY2 //base:static_debian9
     bazel run --host_force_python=PY2 //base:static_debian10
     bazel run --host_force_python=PY2 //base:static-nonroot_debian9


### PR DESCRIPTION
I forgot to update `cloudbuild.yaml` in #477.

#477 changed how we build; we should [build `dpkg_parser.par` first](https://github.com/GoogleContainerTools/distroless/pull/477/files#diff-6a3371457528722a734f3c51d9238c13R18).