### PR TITLE
Adds libuuid1 to the Java distroless images.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -84,6 +84,7 @@ dpkg_list(
         "fonts-dejavu-core",
         "fontconfig-config",
         "libfontconfig1",
+        "libuuid1",
         "openjdk-8-jre-headless",
         "openjdk-8-jdk-headless",
         "openjdk-11-jre-headless",
@@ -301,6 +302,7 @@ dpkg_list(
         "fonts-dejavu-core",
         "fontconfig-config",
         "libfontconfig1",
+        "libuuid1",
         "openjdk-11-jre-headless",
         "openjdk-11-jdk-headless",
 

--- a/java/BUILD
+++ b/java/BUILD
@@ -41,6 +41,7 @@ DISTRO_VERSIONS = {
         DISTRO_PACKAGES[distro_suffix]["fontconfig-config"],
         DISTRO_PACKAGES[distro_suffix]["libexpat1"],
         DISTRO_PACKAGES[distro_suffix]["libfontconfig1"],
+        DISTRO_PACKAGES[distro_suffix]["libuuid1"],
     ] + [DISTRO_PACKAGES[distro_suffix][deb] for deb in java_debs],
     # We expect users to use:
     # cmd = ["/path/to/deploy.jar", "--option1", ...]


### PR DESCRIPTION
I switched over some builds for a project I'm involved with to use the Debian 10-based Java image and noticed that this issue: https://github.com/GoogleContainerTools/distroless/issues/321 seems to have reappeared.

After running with similar debugging flags to the original issue I managed to track it down to a missing `libuuid1` dependency under Debian 10.

This change will also add the dependency to the Debian 9-based image where it is not required but also has no effect.

I've tested this locally and with the project in question and it seems to have fixed the issue.