### PR TITLE
#509: retry with range download to recover from connection close from Debian server

### DIFF
--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -138,7 +138,7 @@ def download_and_save(pkg_key, url, out_file, retry_count=20):
     remained_size -= len(downloaded)
     if remained_size != 0:
         if not range_access_enabled:
-            raise Exception("Fail to downlod %s" % pkg_key)
+            raise Exception("Fail to download %s (%s). Server returned partial contents." %(pkg_key, url))
         offset += len(downloaded)
         while retry_count > 0:
             retry_count -= 1

--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -101,16 +101,14 @@ def download_dpkg(package_files, packages, workspace_name):
             (pkg_version == "" or
             pkg_version == metadata[pkg_name][VERSION_KEY])):
                 pkg = metadata[pkg_name]
-                buf = urllib.request.urlopen(pkg[FILENAME_KEY])
+                out_file = os.path.join("file", util.encode_package_name(pkg_name))
+                download_and_save(pkg_name, pkg[FILENAME_KEY], out_file)
                 package_to_rule_map[pkg_name] = util.package_to_rule(workspace_name, pkg_name)
                 package_to_version_map[pkg_name] = metadata[pkg_name][VERSION_KEY]
-                out_file = os.path.join("file", util.encode_package_name(pkg_name))
-                with io.open(out_file, 'wb') as f:
-                    f.write(buf.read())
-                expected_checksum = util.sha256_checksum(out_file)
-                actual_checksum = pkg[SHA256_KEY]
+                actual_checksum = util.sha256_checksum(out_file)
+                expected_checksum = pkg[SHA256_KEY]
                 if actual_checksum != expected_checksum:
-                    raise Exception("Wrong checksum for package %s.  Expected: %s, Actual: %s" %(pkg_name, expected_checksum, actual_checksum))
+                    raise Exception("Wrong checksum for package %s. %s.  Expected: %s, Actual: %s" %(pkg_name, pkg[FILENAME_KEY], expected_checksum, actual_checksum))
                 if pkg_version == "":
                     break
                 if (pkg_vals in pkg_vals_to_package_file_and_sha256 and
@@ -127,6 +125,39 @@ def download_dpkg(package_files, packages, workspace_name):
     with open(PACKAGE_MAP_FILE_NAME, 'w') as f:
         f.write("packages = " + json.dumps(package_to_rule_map))
         f.write("\nversions = " + json.dumps(package_to_version_map))
+
+def download_and_save(pkg_key, url, out_file, retry_count=20):
+    res = urllib.request.urlopen(url)
+    remained_size = int(res.info().getheader("Content-Length"))
+    range_access_enabled = "bytes" in res.info().getheader("Accept-Ranges")
+    etag = res.info().getheader("ETag")
+    offset = 0
+    contents = []
+    downloaded = res.read()
+    contents.append(downloaded)
+    remained_size -= len(downloaded)
+    if remained_size != 0:
+        if not range_access_enabled:
+            raise Exception("Fail to downlod %s" % pkg_key)
+        offset += len(downloaded)
+        while retry_count > 0:
+            retry_count -= 1
+            req = urllib.request.Request(url, headers={"Range": "bytes=%d-" % offset, "If-Range": etag})
+            res = urllib.request.urlopen(url)
+            if res.getcode() == 200:
+                contents = []
+                offset = 0
+                remained_size = int(res.info().getheader("Content-Length"))
+            downloaded = res.read()
+            contents.append(downloaded)
+            remained_size -= len(downloaded)
+            if remained_size == 0:
+                break
+        if remained_size != 0:
+            raise Exception("Fail to downlod %s. Too many retry." % pkg_key)
+    with io.open(out_file, 'wb') as f:
+        for content in contents:
+            f.write(content)
 
 def download_package_list(mirror_url, distro, arch, snapshot, sha256, packages_gz_url, package_prefix):
     """Downloads a debian package list, expands the relative urls,

--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -143,7 +143,7 @@ def download_and_save(pkg_key, url, out_file, retry_count=20):
         while retry_count > 0:
             retry_count -= 1
             req = urllib.request.Request(url, headers={"Range": "bytes=%d-" % offset, "If-Range": etag})
-            res = urllib.request.urlopen(url)
+            res = urllib.request.urlopen(req)
             if res.getcode() == 200:
                 contents = []
                 offset = 0

--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -154,7 +154,7 @@ def download_and_save(pkg_key, url, out_file, retry_count=20):
             if remained_size == 0:
                 break
         if remained_size != 0:
-            raise Exception("Fail to downlod %s. Too many retry." % pkg_key)
+            raise Exception("Fail to download %s (%s). Too many Range request retries." %(pkg_key, url))
     with io.open(out_file, 'wb') as f:
         for content in contents:
             f.write(content)

--- a/package_manager/dpkg_parser.py
+++ b/package_manager/dpkg_parser.py
@@ -108,7 +108,7 @@ def download_dpkg(package_files, packages, workspace_name):
                 actual_checksum = util.sha256_checksum(out_file)
                 expected_checksum = pkg[SHA256_KEY]
                 if actual_checksum != expected_checksum:
-                    raise Exception("Wrong checksum for package %s. %s.  Expected: %s, Actual: %s" %(pkg_name, pkg[FILENAME_KEY], expected_checksum, actual_checksum))
+                    raise Exception("Wrong checksum for package %s (%s).  Expected: %s, Actual: %s" %(pkg_name, pkg[FILENAME_KEY], expected_checksum, actual_checksum))
                 if pkg_version == "":
                     break
                 if (pkg_vals in pkg_vals_to_package_file_and_sha256 and


### PR DESCRIPTION
This patch is a retry download patch mentioned in https://github.com/GoogleContainerTools/distroless/issues/509.

But on my network/computer, distroless build is timedout. I could not test all build process.