### PR TITLE
Add .dockerignore

### DIFF
--- a/examples/rust/.dockerignore
+++ b/examples/rust/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+target/


### PR DESCRIPTION
I added .git/ and target/ folders to the .dockerignore file, it's also possible to add **/.git and **/target for recursive ignore, but it feels like it's too much intervention for the user.