### PR TITLE
Fix broken cloudbuild.yaml that stalled automatic image publishing

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -134,8 +134,12 @@ steps:
     set -o xtrace
     bazel run --host_force_python=PY2 //experimental/python3:python3_debian9
     bazel run --host_force_python=PY2 //experimental/python3:python3_debian10
+    bazel run --host_force_python=PY2 //experimental/python3:python3_nonroot_debian9
+    bazel run --host_force_python=PY2 //experimental/python3:python3_nonroot_debian10
     bazel run --host_force_python=PY2 //experimental/python3:debug_debian9
     bazel run --host_force_python=PY2 //experimental/python3:debug_debian10
+    bazel run --host_force_python=PY2 //experimental/python3:debug_nonroot_debian9
+    bazel run --host_force_python=PY2 //experimental/python3:debug_nonroot_debian10
 
     bazel run --host_force_python=PY2 //experimental/python2.7:python27_debian9
     bazel run --host_force_python=PY2 //experimental/python2.7:python27_debian10


### PR DESCRIPTION
(from https://github.com/GoogleContainerTools/distroless/pull/521#issuecomment-643320096)

`cloudbuild.yaml` was not building the new Python3 non-root images introduced in #521, and that's why the images have not been published automatically. I've verified that the fixed `cloudbuild.yaml` successfully publishes to my GCP project.

```diff
     bazel run --host_force_python=PY2 //experimental/python3:python3_debian9
     bazel run --host_force_python=PY2 //experimental/python3:python3_debian10
+    bazel run --host_force_python=PY2 //experimental/python3:python3_nonroot_debian9
+    bazel run --host_force_python=PY2 //experimental/python3:python3_nonroot_debian10
     bazel run --host_force_python=PY2 //experimental/python3:debug_debian9
     bazel run --host_force_python=PY2 //experimental/python3:debug_debian10
+    bazel run --host_force_python=PY2 //experimental/python3:debug_nonroot_debian9
+    bazel run --host_force_python=PY2 //experimental/python3:debug_nonroot_debian10
```