### PR TITLE
Fix CI: Failing Java tests due to security update

### DIFF
--- a/java/testdata/java8.yaml
+++ b/java/testdata/java8.yaml
@@ -25,4 +25,4 @@ metadataTest:
   entrypoint: ["/usr/bin/java", "-jar"]
   env:
     - key: 'JAVA_VERSION'
-      value: '8u242'
+      value: '8u252'

--- a/java/testdata/java8_debug.yaml
+++ b/java/testdata/java8_debug.yaml
@@ -26,4 +26,4 @@ metadataTest:
   entrypoint: ["/usr/bin/java", "-jar"]
   env:
     - key: 'JAVA_VERSION'
-      value: '8u242'
+      value: '8u252'


### PR DESCRIPTION
Commit ddaef2acc3 updated the Debian snapshots, which included a
security update to Java 8. Fix the version number in the tests.
Fixes:

    //java:java8_debian9_test
    //java:java8_debug_debian9_test