### PR TITLE
Add java base with image

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -42,7 +42,39 @@ DISTRO_VERSIONS = {
         DISTRO_PACKAGES[distro_suffix]["libexpat1"],
         DISTRO_PACKAGES[distro_suffix]["libfontconfig1"],
         DISTRO_PACKAGES[distro_suffix]["libuuid1"],
-    ] + [DISTRO_PACKAGES[distro_suffix][deb] for deb in java_debs],
+    ],
+    # We expect users to add JAVA_VERSION
+    # env = {
+    #    "JAVA_VERSION": jre_ver(DISTRO_VERSIONS[distro_suffix][java_debs[0]]),
+    # },
+    # We expect users to symlink java executable to /usr/bin/java
+    # symlinks = {
+    #     "/usr/bin/java": java_executable_path,
+    # },
+    tars = [":cacerts_java" + distro_suffix],
+) for (distro_suffix, rule_name) in [
+    (
+        "_debian9",
+        "java_base",
+    ),
+    (
+        "_debian9",
+        "java_base_debug",
+    ),
+    (
+        "_debian10",
+        "java_base",
+    ),
+    (
+        "_debian10",
+        "java_base_debug",
+    ),
+]]
+
+[container_image(
+    name = rule_name + distro_suffix,
+    base = ("//java:java_base" if (not ("debug" in rule_name)) else "//java:java_base_debug") + distro_suffix,
+    debs = [DISTRO_PACKAGES[distro_suffix][deb] for deb in java_debs],
     # We expect users to use:
     # cmd = ["/path/to/deploy.jar", "--option1", ...]
     entrypoint = [
@@ -55,7 +87,6 @@ DISTRO_VERSIONS = {
     symlinks = {
         "/usr/bin/java": java_executable_path,
     },
-    tars = [":cacerts_java" + distro_suffix],
 ) for (distro_suffix, rule_name, java_debs, java_executable_path) in [
     (
         "_debian9",


### PR DESCRIPTION
#439

Opening to start a conversation about supporting future versions of java.

`jlink` is currently the preferred way to make production ready jre images for java version 9 and above (as they no longer ship a jre). Previously discussions related to supporting future versions of java have been closed due to the lack of upstream support in Debian (https://github.com/GoogleContainerTools/distroless/issues/510 https://github.com/GoogleContainerTools/distroless/issues/326).

The goal of this patch is to create a 'blank slate' image where jlinked versions of current and future java releases can be shipped alongside users applications.

Here's an example Dockerfile you could use to build a jlinked image.
```Dockerfile
FROM debian:buster as build
ADD openjdk-14.0.1_linux-x64_bin.tar.gz /opt/jdk
ENV PATH=$PATH:/opt/jdk/jdk-14.0.1/bin
RUN ["jlink",\
"--compress=2",\
"--module-path",\
"/opt/jdk/jdk-14.0.1/jmods",\
"--add-modules",\
"java.base,java.logging,java.xml,jdk.unsupported,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument",\
"--output",\
"/out/usr/lib/jdk-14.0.1"]
RUN mkdir -p /out/usr/bin
RUN ln -s /usr/lib/jdk-14.0.1/bin/java /out/usr/bin/java

FROM bazel/java:java_base_debug_debian10
#FROM gcr.io/distroless/java_base-debian10:11-debug
COPY --from=build /out /
ENTRYPOINT ["/usr/bin/java", "-jar"]
ENV JAVA_VERSION=14.0.1
ADD build/libs/example.jar /
CMD ["example.jar"]
```

Notes
- Any additional images could end up a maintenance burden
- The refactoring adds a new intermediate layer to each of the java images (this could be changed)