### PR TITLE
Added base image for java. Fixes #439

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -249,6 +249,8 @@ images:
   - 'gcr.io/$PROJECT_ID/java:8-debug'
   - 'gcr.io/$PROJECT_ID/java:11'
   - 'gcr.io/$PROJECT_ID/java:11-debug'
+  - 'gcr.io/$PROJECT_ID/java:base'
+  - 'gcr.io/$PROJECT_ID/java:base-debug'
   - 'gcr.io/$PROJECT_ID/java-debian9:base'
   - 'gcr.io/$PROJECT_ID/java-debian9:base-debug'
   - 'gcr.io/$PROJECT_ID/java-debian9:latest'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -95,6 +95,8 @@ steps:
     #!/bin/sh
     set -o errexit
     set -o xtrace
+    docker tag bazel/java:java_base_debian9                 gcr.io/$PROJECT_ID/java-debian9:base
+    docker tag bazel/java:java_base_debug_debian9           gcr.io/$PROJECT_ID/java-debian9:base-debug
     docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java:latest
     docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java:8
     docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java-debian9:latest
@@ -107,6 +109,8 @@ steps:
     docker tag bazel/java:java11_debian9                    gcr.io/$PROJECT_ID/java-debian9:11
     docker tag bazel/java:java11_debug_debian9              gcr.io/$PROJECT_ID/java:11-debug
     docker tag bazel/java:java11_debug_debian9              gcr.io/$PROJECT_ID/java-debian9:11-debug
+    docker tag bazel/java:java_base_debian10                gcr.io/$PROJECT_ID/java-debian10:base
+    docker tag bazel/java:java_base_debug_debian10          gcr.io/$PROJECT_ID/java-debian10:base-debug
     docker tag bazel/java:java11_debian10                   gcr.io/$PROJECT_ID/java-debian10:latest
     docker tag bazel/java:java11_debian10                   gcr.io/$PROJECT_ID/java-debian10:11
     docker tag bazel/java:java11_debug_debian10             gcr.io/$PROJECT_ID/java-debian10:debug
@@ -243,12 +247,16 @@ images:
   - 'gcr.io/$PROJECT_ID/java:8-debug'
   - 'gcr.io/$PROJECT_ID/java:11'
   - 'gcr.io/$PROJECT_ID/java:11-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian9:base'
+  - 'gcr.io/$PROJECT_ID/java-debian9:base-debug'
   - 'gcr.io/$PROJECT_ID/java-debian9:latest'
   - 'gcr.io/$PROJECT_ID/java-debian9:8'
   - 'gcr.io/$PROJECT_ID/java-debian9:debug'
   - 'gcr.io/$PROJECT_ID/java-debian9:8-debug'
   - 'gcr.io/$PROJECT_ID/java-debian9:11'
   - 'gcr.io/$PROJECT_ID/java-debian9:11-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian10:base'
+  - 'gcr.io/$PROJECT_ID/java-debian10:base-debug'
   - 'gcr.io/$PROJECT_ID/java-debian10:latest'
   - 'gcr.io/$PROJECT_ID/java-debian10:11'
   - 'gcr.io/$PROJECT_ID/java-debian10:debug'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -95,7 +95,9 @@ steps:
     #!/bin/sh
     set -o errexit
     set -o xtrace
+    docker tag bazel/java:java_base_debian9                 gcr.io/$PROJECT_ID/java:base
     docker tag bazel/java:java_base_debian9                 gcr.io/$PROJECT_ID/java-debian9:base
+    docker tag bazel/java:java_base_debug_debian9           gcr.io/$PROJECT_ID/java:base-debug
     docker tag bazel/java:java_base_debug_debian9           gcr.io/$PROJECT_ID/java-debian9:base-debug
     docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java:latest
     docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java:8

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -71,6 +71,10 @@ steps:
     #!/bin/sh
     set -o errexit
     set -o xtrace
+    bazel run --host_force_python=PY2 //java:java_base_debian9
+    bazel run --host_force_python=PY2 //java:java_base_debug_debian9
+    bazel run --host_force_python=PY2 //java:java_base_debian10
+    bazel run --host_force_python=PY2 //java:java_base_debug_debian10
     bazel run --host_force_python=PY2 //java:java8_debian9
     bazel run --host_force_python=PY2 //java:java8_debug_debian9
     bazel run --host_force_python=PY2 //java:java11_debian9

--- a/java/BUILD
+++ b/java/BUILD
@@ -136,7 +136,7 @@ alias(
 
 [[container_test(
     name = "java_base" + mode + distro_suffix + "_test",
-    configs = ["testdata/java_base_debug.yaml" if ("debug" in mode) else "testdata/java_base.yaml"],
+    configs = ["testdata/java_base" + mode + ".yaml"],
     image = ":java_base" + mode + distro_suffix,
 ) for mode in [
     "",

--- a/java/BUILD
+++ b/java/BUILD
@@ -28,9 +28,9 @@ DISTRO_VERSIONS = {
     "_debian10",
 ]]
 
-[container_image(
-    name = rule_name + distro_suffix,
-    base = ("//cc:cc" if (not ("debug" in rule_name)) else "//cc:debug") + distro_suffix,
+[[container_image(
+    name = "java_base" + mode + distro_suffix,
+    base = ("//cc:cc" if (not ("debug" in mode)) else "//cc:debug") + distro_suffix,
     debs = [
         DISTRO_PACKAGES[distro_suffix]["zlib1g"],
         DISTRO_PACKAGES[distro_suffix]["libjpeg62-turbo"],
@@ -42,7 +42,17 @@ DISTRO_VERSIONS = {
         DISTRO_PACKAGES[distro_suffix]["libexpat1"],
         DISTRO_PACKAGES[distro_suffix]["libfontconfig1"],
         DISTRO_PACKAGES[distro_suffix]["libuuid1"],
-    ] + [DISTRO_PACKAGES[distro_suffix][deb] for deb in java_debs],
+    ],
+    tars = [":cacerts_java" + distro_suffix],
+) for mode in [
+    "",
+    "_debug",
+]] for distro_suffix in DISTRO_SUFFIXES]
+
+[container_image(
+    name = rule_name + distro_suffix,
+    base = ":java_base" + ("_debug" if ("debug" in rule_name) else "") + distro_suffix,
+    debs = [DISTRO_PACKAGES[distro_suffix][deb] for deb in java_debs],
     # We expect users to use:
     # cmd = ["/path/to/deploy.jar", "--option1", ...]
     entrypoint = [
@@ -55,7 +65,6 @@ DISTRO_VERSIONS = {
     symlinks = {
         "/usr/bin/java": java_executable_path,
     },
-    tars = [":cacerts_java" + distro_suffix],
 ) for (distro_suffix, rule_name, java_debs, java_executable_path) in [
     (
         "_debian9",
@@ -124,6 +133,15 @@ alias(
     name = "java11_debug",
     actual = ":java11_debug_debian9",
 )
+
+[[container_test(
+    name = "java_base" + mode + distro_suffix + "_test",
+    configs = ["testdata/java_base_debug.yaml" if ("debug" in mode) else "testdata/java_base.yaml"],
+    image = ":java_base" + mode + distro_suffix,
+) for mode in [
+    "",
+    "_debug",
+]] for distro_suffix in DISTRO_SUFFIXES]
 
 container_test(
     name = "java8_debian9_test",

--- a/java/testdata/java_base.yaml
+++ b/java/testdata/java_base.yaml
@@ -1,0 +1,14 @@
+schemaVersion: "2.0.0"
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: no-busybox
+    path: "/busybox/sh"
+    shouldExist: false
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+  - name: no-jvm
+    path: "/usr/lib/jvm"
+    shouldExist: false

--- a/java/testdata/java_base_debug.yaml
+++ b/java/testdata/java_base_debug.yaml
@@ -1,0 +1,14 @@
+schemaVersion: "2.0.0"
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: busybox
+    path: "/busybox/sh"
+    shouldExist: true
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+  - name: no-jvm
+    path: "/usr/lib/jvm"
+    shouldExist: false


### PR DESCRIPTION
This PR adds four images for java base.

These images can be used for jlink based jre as mentioned in #439 

Example Usage:

```
FROM amazoncorretto:11 as jreBuilder
RUN jlink \
        --add-modules jdk.unsupported,java.sql,java.desktop,java.naming,java.management,java.instrument,java.security.jgss,java.rmi \
        --verbose \
        --strip-debug \
        --compress 2 \
        --no-header-files \
        --no-man-pages \
        --output /jre

FROM bazel/java:java_base_debian10
ARG JAR_FILE

COPY --from=jreBuilder /jre /usr/lib/jre
ENTRYPOINT ["/usr/lib/jre/bin/java", "-jar", "./app.jar"]
COPY ./target/${JAR_FILE} ./app.jar
```