### PR TITLE
Use two cloudbuild.yaml files to work around Cloud Build limitation

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,16 @@
+# Be sure to break down the "args" of each "step" sufficiently to avoid the
+# 4000-character limit of "args" in Cloud Build.
+
+# - Publishing base, cc, and static as latest is handled in a separate internal
+#   release process
+#
+# - Java images are published by java/cloudbuild.yaml to work around the Cloud
+#   Build 100-image limit.
+#   (https://github.com/GoogleContainerTools/distroless/issues/558)
+
 timeout: 1800s
 steps:
 
-# Publishing base, cc, and static as latest is handled in a separate release process
 - name: gcr.io/cloud-marketplace-containers/google/bazel:3.2.0
   entrypoint: sh
   args:
@@ -71,77 +80,6 @@ steps:
     #!/bin/sh
     set -o errexit
     set -o xtrace
-    bazel run --host_force_python=PY2 //java:java_base_debian9
-    bazel run --host_force_python=PY2 //java:java_base_debug_debian9
-    bazel run --host_force_python=PY2 //java:java_base_debian10
-    bazel run --host_force_python=PY2 //java:java_base_debug_debian10
-    bazel run --host_force_python=PY2 //java:java8_debian9
-    bazel run --host_force_python=PY2 //java:java8_debug_debian9
-    bazel run --host_force_python=PY2 //java:java11_debian9
-    bazel run --host_force_python=PY2 //java:java11_debug_debian9
-    bazel run --host_force_python=PY2 //java:java11_debian10
-    bazel run --host_force_python=PY2 //java:java11_debug_debian10
-    bazel run --host_force_python=PY2 //java/jetty:jetty_java8_debian9
-    bazel run --host_force_python=PY2 //java/jetty:jetty_java8_debug_debian9
-    bazel run --host_force_python=PY2 //java/jetty:jetty_java11_debian9
-    bazel run --host_force_python=PY2 //java/jetty:jetty_java11_debug_debian9
-    bazel run --host_force_python=PY2 //java/jetty:jetty_java11_debian10
-    bazel run --host_force_python=PY2 //java/jetty:jetty_java11_debug_debian10
-- name: gcr.io/cloud-builders/docker
-  entrypoint: sh
-  args:
-  - -c
-  - |
-    #!/bin/sh
-    set -o errexit
-    set -o xtrace
-    docker tag bazel/java:java_base_debian9                 gcr.io/$PROJECT_ID/java:base
-    docker tag bazel/java:java_base_debian9                 gcr.io/$PROJECT_ID/java-debian9:base
-    docker tag bazel/java:java_base_debug_debian9           gcr.io/$PROJECT_ID/java:base-debug
-    docker tag bazel/java:java_base_debug_debian9           gcr.io/$PROJECT_ID/java-debian9:base-debug
-    docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java:latest
-    docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java:8
-    docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java-debian9:latest
-    docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java-debian9:8
-    docker tag bazel/java:java8_debug_debian9               gcr.io/$PROJECT_ID/java:debug
-    docker tag bazel/java:java8_debug_debian9               gcr.io/$PROJECT_ID/java:8-debug
-    docker tag bazel/java:java8_debug_debian9               gcr.io/$PROJECT_ID/java-debian9:debug
-    docker tag bazel/java:java8_debug_debian9               gcr.io/$PROJECT_ID/java-debian9:8-debug
-    docker tag bazel/java:java11_debian9                    gcr.io/$PROJECT_ID/java:11
-    docker tag bazel/java:java11_debian9                    gcr.io/$PROJECT_ID/java-debian9:11
-    docker tag bazel/java:java11_debug_debian9              gcr.io/$PROJECT_ID/java:11-debug
-    docker tag bazel/java:java11_debug_debian9              gcr.io/$PROJECT_ID/java-debian9:11-debug
-    docker tag bazel/java:java_base_debian10                gcr.io/$PROJECT_ID/java-debian10:base
-    docker tag bazel/java:java_base_debug_debian10          gcr.io/$PROJECT_ID/java-debian10:base-debug
-    docker tag bazel/java:java11_debian10                   gcr.io/$PROJECT_ID/java-debian10:latest
-    docker tag bazel/java:java11_debian10                   gcr.io/$PROJECT_ID/java-debian10:11
-    docker tag bazel/java:java11_debug_debian10             gcr.io/$PROJECT_ID/java-debian10:debug
-    docker tag bazel/java:java11_debug_debian10             gcr.io/$PROJECT_ID/java-debian10:11-debug
-    docker tag bazel/java/jetty:jetty_java8_debian9         gcr.io/$PROJECT_ID/java/jetty:latest
-    docker tag bazel/java/jetty:jetty_java8_debian9         gcr.io/$PROJECT_ID/java/jetty:java8
-    docker tag bazel/java/jetty:jetty_java8_debian9         gcr.io/$PROJECT_ID/java-debian9/jetty:latest
-    docker tag bazel/java/jetty:jetty_java8_debian9         gcr.io/$PROJECT_ID/java-debian9/jetty:java8
-    docker tag bazel/java/jetty:jetty_java8_debug_debian9   gcr.io/$PROJECT_ID/java/jetty:debug
-    docker tag bazel/java/jetty:jetty_java8_debug_debian9   gcr.io/$PROJECT_ID/java/jetty:java8-debug
-    docker tag bazel/java/jetty:jetty_java8_debug_debian9   gcr.io/$PROJECT_ID/java-debian9/jetty:debug
-    docker tag bazel/java/jetty:jetty_java8_debug_debian9   gcr.io/$PROJECT_ID/java-debian9/jetty:java8-debug
-    docker tag bazel/java/jetty:jetty_java11_debian9        gcr.io/$PROJECT_ID/java/jetty:java11
-    docker tag bazel/java/jetty:jetty_java11_debian9        gcr.io/$PROJECT_ID/java-debian9/jetty:java11
-    docker tag bazel/java/jetty:jetty_java11_debug_debian9  gcr.io/$PROJECT_ID/java/jetty:java11-debug
-    docker tag bazel/java/jetty:jetty_java11_debug_debian9  gcr.io/$PROJECT_ID/java-debian9/jetty:java11-debug
-    docker tag bazel/java/jetty:jetty_java11_debian10       gcr.io/$PROJECT_ID/java-debian10/jetty:latest
-    docker tag bazel/java/jetty:jetty_java11_debian10       gcr.io/$PROJECT_ID/java-debian10/jetty:java11
-    docker tag bazel/java/jetty:jetty_java11_debug_debian10 gcr.io/$PROJECT_ID/java-debian10/jetty:debug
-    docker tag bazel/java/jetty:jetty_java11_debug_debian10 gcr.io/$PROJECT_ID/java-debian10/jetty:java11-debug
-
-- name: gcr.io/cloud-marketplace-containers/google/bazel:3.2.0
-  entrypoint: sh
-  args:
-  - -c
-  - |
-    #!/bin/sh
-    set -o errexit
-    set -o xtrace
     bazel run --host_force_python=PY2 //experimental/python3:python3_debian9
     bazel run --host_force_python=PY2 //experimental/python3:python3_debian10
     bazel run --host_force_python=PY2 //experimental/python3:python3_nonroot_debian9
@@ -162,18 +100,6 @@ steps:
     bazel run --host_force_python=PY2 //experimental/nodejs:nodejs12_debug
     bazel run --host_force_python=PY2 //experimental/nodejs:nodejs14
     bazel run --host_force_python=PY2 //experimental/nodejs:nodejs14_debug
-
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_debian9
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_debian10
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_aspnet_debian9
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_runtime_debian9
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_sdk_debian9
-
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_debug_debian9
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_debug_debian10
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_aspnet_debug_debian9
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_runtime_debug_debian9
-    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_sdk_debug_debian9
 - name: gcr.io/cloud-builders/docker
   entrypoint: sh
   args:
@@ -211,6 +137,33 @@ steps:
     docker tag bazel/experimental/nodejs:nodejs12_debug gcr.io/$PROJECT_ID/nodejs:12-debug
     docker tag bazel/experimental/nodejs:nodejs14_debug gcr.io/$PROJECT_ID/nodejs:14-debug
 
+- name: gcr.io/cloud-marketplace-containers/google/bazel:3.2.0
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_debian9
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_debian10
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_aspnet_debian9
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_runtime_debian9
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_sdk_debian9
+
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_debug_debian9
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_debug_debian10
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_aspnet_debug_debian9
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_runtime_debug_debian9
+    bazel run --host_force_python=PY2 //experimental/dotnet:dotnet_core_sdk_debug_debian9
+- name: gcr.io/cloud-builders/docker
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
     docker tag bazel/experimental/dotnet:dotnet_debian9                    gcr.io/$PROJECT_ID/dotnet:latest
     docker tag bazel/experimental/dotnet:dotnet_debian9                    gcr.io/$PROJECT_ID/dotnet-debian9:latest
     docker tag bazel/experimental/dotnet:dotnet_debian10                   gcr.io/$PROJECT_ID/dotnet-debian10:latest
@@ -253,44 +206,6 @@ images:
   - 'gcr.io/$PROJECT_ID/cc-debian9:debug'
   - 'gcr.io/$PROJECT_ID/cc-debian10:${COMMIT_SHA}'
   - 'gcr.io/$PROJECT_ID/cc-debian10:debug'
-  - 'gcr.io/$PROJECT_ID/java:latest'
-  - 'gcr.io/$PROJECT_ID/java:8'
-  - 'gcr.io/$PROJECT_ID/java:debug'
-  - 'gcr.io/$PROJECT_ID/java:8-debug'
-  - 'gcr.io/$PROJECT_ID/java:11'
-  - 'gcr.io/$PROJECT_ID/java:11-debug'
-  - 'gcr.io/$PROJECT_ID/java:base'
-  - 'gcr.io/$PROJECT_ID/java:base-debug'
-  - 'gcr.io/$PROJECT_ID/java-debian9:base'
-  - 'gcr.io/$PROJECT_ID/java-debian9:base-debug'
-  - 'gcr.io/$PROJECT_ID/java-debian9:latest'
-  - 'gcr.io/$PROJECT_ID/java-debian9:8'
-  - 'gcr.io/$PROJECT_ID/java-debian9:debug'
-  - 'gcr.io/$PROJECT_ID/java-debian9:8-debug'
-  - 'gcr.io/$PROJECT_ID/java-debian9:11'
-  - 'gcr.io/$PROJECT_ID/java-debian9:11-debug'
-  - 'gcr.io/$PROJECT_ID/java-debian10:base'
-  - 'gcr.io/$PROJECT_ID/java-debian10:base-debug'
-  - 'gcr.io/$PROJECT_ID/java-debian10:latest'
-  - 'gcr.io/$PROJECT_ID/java-debian10:11'
-  - 'gcr.io/$PROJECT_ID/java-debian10:debug'
-  - 'gcr.io/$PROJECT_ID/java-debian10:11-debug'
-  - 'gcr.io/$PROJECT_ID/java/jetty:latest'
-  - 'gcr.io/$PROJECT_ID/java/jetty:java8'
-  - 'gcr.io/$PROJECT_ID/java/jetty:debug'
-  - 'gcr.io/$PROJECT_ID/java/jetty:java8-debug'
-  - 'gcr.io/$PROJECT_ID/java/jetty:java11'
-  - 'gcr.io/$PROJECT_ID/java/jetty:java11-debug'
-  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:latest'
-  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:java8'
-  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:debug'
-  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:java8-debug'
-  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:java11'
-  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:java11-debug'
-  - 'gcr.io/$PROJECT_ID/java-debian10/jetty:latest'
-  - 'gcr.io/$PROJECT_ID/java-debian10/jetty:java11'
-  - 'gcr.io/$PROJECT_ID/java-debian10/jetty:debug'
-  - 'gcr.io/$PROJECT_ID/java-debian10/jetty:java11-debug'
   - 'gcr.io/$PROJECT_ID/python3:latest'
   - 'gcr.io/$PROJECT_ID/python3:nonroot'
   - 'gcr.io/$PROJECT_ID/python3:debug'

--- a/java/cloudbuild.yaml
+++ b/java/cloudbuild.yaml
@@ -1,0 +1,135 @@
+# Be sure to break down the "args" of each "step" sufficiently to avoid the
+# 4000-character limit of "args" in Cloud Build.
+
+timeout: 1800s
+steps:
+
+- name: gcr.io/cloud-marketplace-containers/google/bazel:3.2.0
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
+    bazel build --host_force_python=PY2 //package_manager:dpkg_parser.par
+
+    bazel run --host_force_python=PY2 //java:java_base_debian9
+    bazel run --host_force_python=PY2 //java:java_base_debug_debian9
+    bazel run --host_force_python=PY2 //java:java_base_debian10
+    bazel run --host_force_python=PY2 //java:java_base_debug_debian10
+    bazel run --host_force_python=PY2 //java:java8_debian9
+    bazel run --host_force_python=PY2 //java:java8_debug_debian9
+    bazel run --host_force_python=PY2 //java:java11_debian9
+    bazel run --host_force_python=PY2 //java:java11_debug_debian9
+    bazel run --host_force_python=PY2 //java:java11_debian10
+    bazel run --host_force_python=PY2 //java:java11_debug_debian10
+- name: gcr.io/cloud-marketplace-containers/google/bazel:3.2.0
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
+
+    bazel run --host_force_python=PY2 //java/jetty:jetty_java8_debian9
+    bazel run --host_force_python=PY2 //java/jetty:jetty_java8_debug_debian9
+    bazel run --host_force_python=PY2 //java/jetty:jetty_java11_debian9
+    bazel run --host_force_python=PY2 //java/jetty:jetty_java11_debug_debian9
+    bazel run --host_force_python=PY2 //java/jetty:jetty_java11_debian10
+    bazel run --host_force_python=PY2 //java/jetty:jetty_java11_debug_debian10
+- name: gcr.io/cloud-builders/docker
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
+    docker tag bazel/java:java_base_debian9                 gcr.io/$PROJECT_ID/java:base
+    docker tag bazel/java:java_base_debian9                 gcr.io/$PROJECT_ID/java-debian9:base
+    docker tag bazel/java:java_base_debug_debian9           gcr.io/$PROJECT_ID/java:base-debug
+    docker tag bazel/java:java_base_debug_debian9           gcr.io/$PROJECT_ID/java-debian9:base-debug
+    docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java:latest
+    docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java:8
+    docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java-debian9:latest
+    docker tag bazel/java:java8_debian9                     gcr.io/$PROJECT_ID/java-debian9:8
+    docker tag bazel/java:java8_debug_debian9               gcr.io/$PROJECT_ID/java:debug
+    docker tag bazel/java:java8_debug_debian9               gcr.io/$PROJECT_ID/java:8-debug
+    docker tag bazel/java:java8_debug_debian9               gcr.io/$PROJECT_ID/java-debian9:debug
+    docker tag bazel/java:java8_debug_debian9               gcr.io/$PROJECT_ID/java-debian9:8-debug
+    docker tag bazel/java:java11_debian9                    gcr.io/$PROJECT_ID/java:11
+    docker tag bazel/java:java11_debian9                    gcr.io/$PROJECT_ID/java-debian9:11
+    docker tag bazel/java:java11_debug_debian9              gcr.io/$PROJECT_ID/java:11-debug
+    docker tag bazel/java:java11_debug_debian9              gcr.io/$PROJECT_ID/java-debian9:11-debug
+    docker tag bazel/java:java_base_debian10                gcr.io/$PROJECT_ID/java-debian10:base
+    docker tag bazel/java:java_base_debug_debian10          gcr.io/$PROJECT_ID/java-debian10:base-debug
+    docker tag bazel/java:java11_debian10                   gcr.io/$PROJECT_ID/java-debian10:latest
+    docker tag bazel/java:java11_debian10                   gcr.io/$PROJECT_ID/java-debian10:11
+    docker tag bazel/java:java11_debug_debian10             gcr.io/$PROJECT_ID/java-debian10:debug
+    docker tag bazel/java:java11_debug_debian10             gcr.io/$PROJECT_ID/java-debian10:11-debug
+- name: gcr.io/cloud-builders/docker
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
+    docker tag bazel/java/jetty:jetty_java8_debian9         gcr.io/$PROJECT_ID/java/jetty:latest
+    docker tag bazel/java/jetty:jetty_java8_debian9         gcr.io/$PROJECT_ID/java/jetty:java8
+    docker tag bazel/java/jetty:jetty_java8_debian9         gcr.io/$PROJECT_ID/java-debian9/jetty:latest
+    docker tag bazel/java/jetty:jetty_java8_debian9         gcr.io/$PROJECT_ID/java-debian9/jetty:java8
+    docker tag bazel/java/jetty:jetty_java8_debug_debian9   gcr.io/$PROJECT_ID/java/jetty:debug
+    docker tag bazel/java/jetty:jetty_java8_debug_debian9   gcr.io/$PROJECT_ID/java/jetty:java8-debug
+    docker tag bazel/java/jetty:jetty_java8_debug_debian9   gcr.io/$PROJECT_ID/java-debian9/jetty:debug
+    docker tag bazel/java/jetty:jetty_java8_debug_debian9   gcr.io/$PROJECT_ID/java-debian9/jetty:java8-debug
+    docker tag bazel/java/jetty:jetty_java11_debian9        gcr.io/$PROJECT_ID/java/jetty:java11
+    docker tag bazel/java/jetty:jetty_java11_debian9        gcr.io/$PROJECT_ID/java-debian9/jetty:java11
+    docker tag bazel/java/jetty:jetty_java11_debug_debian9  gcr.io/$PROJECT_ID/java/jetty:java11-debug
+    docker tag bazel/java/jetty:jetty_java11_debug_debian9  gcr.io/$PROJECT_ID/java-debian9/jetty:java11-debug
+    docker tag bazel/java/jetty:jetty_java11_debian10       gcr.io/$PROJECT_ID/java-debian10/jetty:latest
+    docker tag bazel/java/jetty:jetty_java11_debian10       gcr.io/$PROJECT_ID/java-debian10/jetty:java11
+    docker tag bazel/java/jetty:jetty_java11_debug_debian10 gcr.io/$PROJECT_ID/java-debian10/jetty:debug
+    docker tag bazel/java/jetty:jetty_java11_debug_debian10 gcr.io/$PROJECT_ID/java-debian10/jetty:java11-debug
+
+images:
+  - 'gcr.io/$PROJECT_ID/java:latest'
+  - 'gcr.io/$PROJECT_ID/java:8'
+  - 'gcr.io/$PROJECT_ID/java:debug'
+  - 'gcr.io/$PROJECT_ID/java:8-debug'
+  - 'gcr.io/$PROJECT_ID/java:11'
+  - 'gcr.io/$PROJECT_ID/java:11-debug'
+  - 'gcr.io/$PROJECT_ID/java:base'
+  - 'gcr.io/$PROJECT_ID/java:base-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian9:base'
+  - 'gcr.io/$PROJECT_ID/java-debian9:base-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian9:latest'
+  - 'gcr.io/$PROJECT_ID/java-debian9:8'
+  - 'gcr.io/$PROJECT_ID/java-debian9:debug'
+  - 'gcr.io/$PROJECT_ID/java-debian9:8-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian9:11'
+  - 'gcr.io/$PROJECT_ID/java-debian9:11-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian10:base'
+  - 'gcr.io/$PROJECT_ID/java-debian10:base-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian10:latest'
+  - 'gcr.io/$PROJECT_ID/java-debian10:11'
+  - 'gcr.io/$PROJECT_ID/java-debian10:debug'
+  - 'gcr.io/$PROJECT_ID/java-debian10:11-debug'
+  - 'gcr.io/$PROJECT_ID/java/jetty:latest'
+  - 'gcr.io/$PROJECT_ID/java/jetty:java8'
+  - 'gcr.io/$PROJECT_ID/java/jetty:debug'
+  - 'gcr.io/$PROJECT_ID/java/jetty:java8-debug'
+  - 'gcr.io/$PROJECT_ID/java/jetty:java11'
+  - 'gcr.io/$PROJECT_ID/java/jetty:java11-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:latest'
+  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:java8'
+  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:debug'
+  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:java8-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:java11'
+  - 'gcr.io/$PROJECT_ID/java-debian9/jetty:java11-debug'
+  - 'gcr.io/$PROJECT_ID/java-debian10/jetty:latest'
+  - 'gcr.io/$PROJECT_ID/java-debian10/jetty:java11'
+  - 'gcr.io/$PROJECT_ID/java-debian10/jetty:debug'
+  - 'gcr.io/$PROJECT_ID/java-debian10/jetty:java11-debug'


### PR DESCRIPTION
Fixes #558.

Separates out Java image publishing from `/cloudbuild.yaml` into `/java/cloudbuild.yaml` to overcome #558. I ran these `cloudbuild.yaml` files locally to publish images to my personal GCP project and they succeeded.

Turns out the release pipeline was just a Cloud Build trigger on the Distroless GCP project. (_Cloud Build_ > _Triggers_ on Google Cloud Console (console.cloud.google.com)). I added a new trigger for `/java/cloudbuild.yaml` on GCP.

While fixing this, locally I encountered the 4000-character limit of `args:` which I hadn't seen before.
```
... : invalid .steps field: build step 1 arg 1 too long (max: 4000)
```
Not sure if it affects the actual Cloud Build release, because at least the release pipeline ran successfully last Monday. However, to be able to test this locally, I needed to break down long steps.