### PR TITLE
Publish latest tags on base, cc, and static

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,9 +1,6 @@
 # Be sure to break down the "args" of each "step" sufficiently to avoid the
 # 4000-character limit of "args" in Cloud Build.
 
-# - Publishing base, cc, and static as latest is handled in a separate internal
-#   release process
-#
 # - Java images are published by java/cloudbuild.yaml to work around the Cloud
 #   Build 100-image limit.
 #   (https://github.com/GoogleContainerTools/distroless/issues/558)
@@ -47,14 +44,20 @@ steps:
     set -o errexit
     set -o xtrace
     docker tag bazel/base:static_debian9          gcr.io/$PROJECT_ID/static:${COMMIT_SHA}
+    docker tag bazel/base:static_debian9          gcr.io/$PROJECT_ID/static:latest
     docker tag bazel/base:static_debian9          gcr.io/$PROJECT_ID/static-debian9:${COMMIT_SHA}
+    docker tag bazel/base:static_debian9          gcr.io/$PROJECT_ID/static-debian9:latest
     docker tag bazel/base:static_debian10         gcr.io/$PROJECT_ID/static-debian10:${COMMIT_SHA}
+    docker tag bazel/base:static_debian10         gcr.io/$PROJECT_ID/static-debian10:latest
     docker tag bazel/base:static_nonroot_debian9  gcr.io/$PROJECT_ID/static:nonroot
     docker tag bazel/base:static_nonroot_debian9  gcr.io/$PROJECT_ID/static-debian9:nonroot
     docker tag bazel/base:static_nonroot_debian10 gcr.io/$PROJECT_ID/static-debian10:nonroot
     docker tag bazel/base:base_debian9            gcr.io/$PROJECT_ID/base:${COMMIT_SHA}
+    docker tag bazel/base:base_debian9            gcr.io/$PROJECT_ID/base:latest
     docker tag bazel/base:base_debian9            gcr.io/$PROJECT_ID/base-debian9:${COMMIT_SHA}
+    docker tag bazel/base:base_debian9            gcr.io/$PROJECT_ID/base-debian9:latest
     docker tag bazel/base:base_debian10           gcr.io/$PROJECT_ID/base-debian10:${COMMIT_SHA}
+    docker tag bazel/base:base_debian10           gcr.io/$PROJECT_ID/base-debian10:latest
     docker tag bazel/base:base_nonroot_debian9    gcr.io/$PROJECT_ID/base:nonroot
     docker tag bazel/base:base_nonroot_debian9    gcr.io/$PROJECT_ID/base-debian9:nonroot
     docker tag bazel/base:base_nonroot_debian10   gcr.io/$PROJECT_ID/base-debian10:nonroot
@@ -66,8 +69,11 @@ steps:
     docker tag bazel/base:debug_nonroot_debian10  gcr.io/$PROJECT_ID/base-debian10:debug-nonroot
 
     docker tag bazel/cc:cc_debian9     gcr.io/$PROJECT_ID/cc:${COMMIT_SHA}
+    docker tag bazel/cc:cc_debian9     gcr.io/$PROJECT_ID/cc:latest
     docker tag bazel/cc:cc_debian9     gcr.io/$PROJECT_ID/cc-debian9:${COMMIT_SHA}
+    docker tag bazel/cc:cc_debian9     gcr.io/$PROJECT_ID/cc-debian9:latest
     docker tag bazel/cc:cc_debian10    gcr.io/$PROJECT_ID/cc-debian10:${COMMIT_SHA}
+    docker tag bazel/cc:cc_debian10    gcr.io/$PROJECT_ID/cc-debian10:latest
     docker tag bazel/cc:debug_debian9  gcr.io/$PROJECT_ID/cc:debug
     docker tag bazel/cc:debug_debian9  gcr.io/$PROJECT_ID/cc-debian9:debug
     docker tag bazel/cc:debug_debian10 gcr.io/$PROJECT_ID/cc-debian10:debug
@@ -183,28 +189,37 @@ steps:
 
 images:
   - 'gcr.io/$PROJECT_ID/static:${COMMIT_SHA}'
+  - 'gcr.io/$PROJECT_ID/static:latest'
   - 'gcr.io/$PROJECT_ID/static:nonroot'
   - 'gcr.io/$PROJECT_ID/static-debian9:${COMMIT_SHA}'
+  - 'gcr.io/$PROJECT_ID/static-debian9:latest'
   - 'gcr.io/$PROJECT_ID/static-debian9:nonroot'
   - 'gcr.io/$PROJECT_ID/static-debian10:${COMMIT_SHA}'
+  - 'gcr.io/$PROJECT_ID/static-debian10:latest'
   - 'gcr.io/$PROJECT_ID/static-debian10:nonroot'
   - 'gcr.io/$PROJECT_ID/base:${COMMIT_SHA}'
+  - 'gcr.io/$PROJECT_ID/base:latest'
   - 'gcr.io/$PROJECT_ID/base:nonroot'
   - 'gcr.io/$PROJECT_ID/base:debug'
   - 'gcr.io/$PROJECT_ID/base:debug-nonroot'
   - 'gcr.io/$PROJECT_ID/base-debian9:${COMMIT_SHA}'
+  - 'gcr.io/$PROJECT_ID/base-debian9:latest'
   - 'gcr.io/$PROJECT_ID/base-debian9:nonroot'
   - 'gcr.io/$PROJECT_ID/base-debian9:debug'
   - 'gcr.io/$PROJECT_ID/base-debian9:debug-nonroot'
   - 'gcr.io/$PROJECT_ID/base-debian10:${COMMIT_SHA}'
+  - 'gcr.io/$PROJECT_ID/base-debian10:latest'
   - 'gcr.io/$PROJECT_ID/base-debian10:nonroot'
   - 'gcr.io/$PROJECT_ID/base-debian10:debug'
   - 'gcr.io/$PROJECT_ID/base-debian10:debug-nonroot'
   - 'gcr.io/$PROJECT_ID/cc:${COMMIT_SHA}'
+  - 'gcr.io/$PROJECT_ID/cc:latest'
   - 'gcr.io/$PROJECT_ID/cc:debug'
   - 'gcr.io/$PROJECT_ID/cc-debian9:${COMMIT_SHA}'
+  - 'gcr.io/$PROJECT_ID/cc-debian9:latest'
   - 'gcr.io/$PROJECT_ID/cc-debian9:debug'
   - 'gcr.io/$PROJECT_ID/cc-debian10:${COMMIT_SHA}'
+  - 'gcr.io/$PROJECT_ID/cc-debian10:latest'
   - 'gcr.io/$PROJECT_ID/cc-debian10:debug'
   - 'gcr.io/$PROJECT_ID/python3:latest'
   - 'gcr.io/$PROJECT_ID/python3:nonroot'


### PR DESCRIPTION
Fixes #566.

New tags:

- `gcr.io/distroless/base:latest`
- `gcr.io/distroless/base-debian9:latest`
- `gcr.io/distroless/base-debian10:latest`
- `gcr.io/distroless/cc:latest`
- `gcr.io/distroless/cc-debian9:latest`
- `gcr.io/distroless/cc-debian10:latest`
- `gcr.io/distroless/static:latest`
- `gcr.io/distroless/static-debian9:latest`
- `gcr.io/distroless/static-debian10:latest`

This will take effect only after removing the internal system controlling these tags.

Related: #436 #483

---

The Debian snapshot package repo has been very unstable recently, so tests are very flaky. 