### PR TITLE
Publish static images as manifest lists.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -50,12 +50,12 @@ steps:
     set -o xtrace
 
     docker tag bazel/base:static_root_amd64_debian9     gcr.io/$PROJECT_ID/static:${COMMIT_SHA}
-    docker tag bazel/base:static_root_amd64_debian9     gcr.io/$PROJECT_ID/static:latest
+    docker tag bazel/base:static_root_amd64_debian9     gcr.io/$PROJECT_ID/static:latest-amd64
     docker tag bazel/base:static_root_amd64_debian9     gcr.io/$PROJECT_ID/static-debian9:${COMMIT_SHA}
     docker tag bazel/base:static_root_amd64_debian9     gcr.io/$PROJECT_ID/static-debian9:latest
     docker tag bazel/base:static_root_amd64_debian10    gcr.io/$PROJECT_ID/static-debian10:${COMMIT_SHA}
     docker tag bazel/base:static_root_amd64_debian10    gcr.io/$PROJECT_ID/static-debian10:latest
-    docker tag bazel/base:static_nonroot_amd64_debian9  gcr.io/$PROJECT_ID/static:nonroot
+    docker tag bazel/base:static_nonroot_amd64_debian9  gcr.io/$PROJECT_ID/static:nonroot-amd64
     docker tag bazel/base:static_nonroot_amd64_debian9  gcr.io/$PROJECT_ID/static-debian9:nonroot
     docker tag bazel/base:static_nonroot_amd64_debian10 gcr.io/$PROJECT_ID/static-debian10:nonroot
 
@@ -233,96 +233,145 @@ steps:
     docker tag bazel/experimental/dotnet:dotnet_core_sdk_debian9           gcr.io/$PROJECT_ID/dotnet/core/sdk:3.1
     docker tag bazel/experimental/dotnet:dotnet_core_sdk_debug_debian9     gcr.io/$PROJECT_ID/dotnet/core/sdk:debug
 
-images:
-  - 'gcr.io/$PROJECT_ID/static:${COMMIT_SHA}'
-  - 'gcr.io/$PROJECT_ID/static:latest'
-  - 'gcr.io/$PROJECT_ID/static:nonroot'
-  - 'gcr.io/$PROJECT_ID/static:latest-arm64'
-  - 'gcr.io/$PROJECT_ID/static:nonroot-arm64'
-  - 'gcr.io/$PROJECT_ID/static-debian9:${COMMIT_SHA}'
-  - 'gcr.io/$PROJECT_ID/static-debian9:latest'
-  - 'gcr.io/$PROJECT_ID/static-debian9:nonroot'
-  - 'gcr.io/$PROJECT_ID/static-debian10:${COMMIT_SHA}'
-  - 'gcr.io/$PROJECT_ID/static-debian10:latest'
-  - 'gcr.io/$PROJECT_ID/static-debian10:nonroot'
-  - 'gcr.io/$PROJECT_ID/base:${COMMIT_SHA}'
-  - 'gcr.io/$PROJECT_ID/base:latest'
-  - 'gcr.io/$PROJECT_ID/base:nonroot'
-  - 'gcr.io/$PROJECT_ID/base:debug'
-  - 'gcr.io/$PROJECT_ID/base:debug-nonroot'
-  - 'gcr.io/$PROJECT_ID/base-debian9:${COMMIT_SHA}'
-  - 'gcr.io/$PROJECT_ID/base-debian9:latest'
-  - 'gcr.io/$PROJECT_ID/base-debian9:nonroot'
-  - 'gcr.io/$PROJECT_ID/base-debian9:debug'
-  - 'gcr.io/$PROJECT_ID/base-debian9:debug-nonroot'
-  - 'gcr.io/$PROJECT_ID/base-debian10:${COMMIT_SHA}'
-  - 'gcr.io/$PROJECT_ID/base-debian10:latest'
-  - 'gcr.io/$PROJECT_ID/base-debian10:nonroot'
-  - 'gcr.io/$PROJECT_ID/base-debian10:debug'
-  - 'gcr.io/$PROJECT_ID/base-debian10:debug-nonroot'
-  - 'gcr.io/$PROJECT_ID/cc:${COMMIT_SHA}'
-  - 'gcr.io/$PROJECT_ID/cc:latest'
-  - 'gcr.io/$PROJECT_ID/cc:debug'
-  - 'gcr.io/$PROJECT_ID/cc-debian9:${COMMIT_SHA}'
-  - 'gcr.io/$PROJECT_ID/cc-debian9:latest'
-  - 'gcr.io/$PROJECT_ID/cc-debian9:debug'
-  - 'gcr.io/$PROJECT_ID/cc-debian10:${COMMIT_SHA}'
-  - 'gcr.io/$PROJECT_ID/cc-debian10:latest'
-  - 'gcr.io/$PROJECT_ID/cc-debian10:debug'
-  - 'gcr.io/$PROJECT_ID/python3:latest'
-  - 'gcr.io/$PROJECT_ID/python3:nonroot'
-  - 'gcr.io/$PROJECT_ID/python3:debug'
-  - 'gcr.io/$PROJECT_ID/python3:debug-nonroot'
-  - 'gcr.io/$PROJECT_ID/python3-debian9:latest'
-  - 'gcr.io/$PROJECT_ID/python3-debian9:nonroot'
-  - 'gcr.io/$PROJECT_ID/python3-debian9:debug'
-  - 'gcr.io/$PROJECT_ID/python3-debian9:debug-nonroot'
-  - 'gcr.io/$PROJECT_ID/python3-debian10:latest'
-  - 'gcr.io/$PROJECT_ID/python3-debian10:nonroot'
-  - 'gcr.io/$PROJECT_ID/python3-debian10:debug'
-  - 'gcr.io/$PROJECT_ID/python3-debian10:debug-nonroot'
-  - 'gcr.io/$PROJECT_ID/python2.7:latest'
-  - 'gcr.io/$PROJECT_ID/python2.7:debug'
-  - 'gcr.io/$PROJECT_ID/python2.7-debian9:latest'
-  - 'gcr.io/$PROJECT_ID/python2.7-debian9:debug'
-  - 'gcr.io/$PROJECT_ID/python2.7-debian10:latest'
-  - 'gcr.io/$PROJECT_ID/python2.7-debian10:debug'
-  - 'gcr.io/$PROJECT_ID/nodejs:latest'
-  - 'gcr.io/$PROJECT_ID/nodejs:10'
-  - 'gcr.io/$PROJECT_ID/nodejs:12'
-  - 'gcr.io/$PROJECT_ID/nodejs:14'
-  - 'gcr.io/$PROJECT_ID/nodejs:debug'
-  - 'gcr.io/$PROJECT_ID/nodejs:10-debug'
-  - 'gcr.io/$PROJECT_ID/nodejs:12-debug'
-  - 'gcr.io/$PROJECT_ID/nodejs:14-debug'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian9:latest'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian9:10'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian9:12'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian9:14'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian9:debug'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian9:10-debug'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian9:12-debug'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian9:14-debug'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian10:latest'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian10:10'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian10:12'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian10:14'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian10:debug'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian10:10-debug'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian10:12-debug'
-  - 'gcr.io/$PROJECT_ID/nodejs-debian10:14-debug'
-  - 'gcr.io/$PROJECT_ID/dotnet:latest'
-  - 'gcr.io/$PROJECT_ID/dotnet:debug'
-  - 'gcr.io/$PROJECT_ID/dotnet-debian9:latest'
-  - 'gcr.io/$PROJECT_ID/dotnet-debian9:debug'
-  - 'gcr.io/$PROJECT_ID/dotnet-debian10:latest'
-  - 'gcr.io/$PROJECT_ID/dotnet-debian10:debug'
-  - 'gcr.io/$PROJECT_ID/dotnet/core/aspnet:latest'
-  - 'gcr.io/$PROJECT_ID/dotnet/core/aspnet:3.1'
-  - 'gcr.io/$PROJECT_ID/dotnet/core/aspnet:debug'
-  - 'gcr.io/$PROJECT_ID/dotnet/core/runtime:latest'
-  - 'gcr.io/$PROJECT_ID/dotnet/core/runtime:3.1'
-  - 'gcr.io/$PROJECT_ID/dotnet/core/runtime:debug'
-  - 'gcr.io/$PROJECT_ID/dotnet/core/sdk:latest'
-  - 'gcr.io/$PROJECT_ID/dotnet/core/sdk:3.1'
-  - 'gcr.io/$PROJECT_ID/dotnet/core/sdk:debug'
+- name: docker
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
+
+    # First publish the individual container images, we do this manually because we
+    # want to publish manifest lists next, which GCB does not support.
+    docker push 'gcr.io/$PROJECT_ID/static:${COMMIT_SHA}'
+    docker push 'gcr.io/$PROJECT_ID/static:latest-amd64'
+    docker push 'gcr.io/$PROJECT_ID/static:nonroot-amd64'
+    docker push 'gcr.io/$PROJECT_ID/static:latest-arm64'
+    docker push 'gcr.io/$PROJECT_ID/static:nonroot-arm64'
+    docker push 'gcr.io/$PROJECT_ID/static-debian9:${COMMIT_SHA}'
+    docker push 'gcr.io/$PROJECT_ID/static-debian9:latest'
+    docker push 'gcr.io/$PROJECT_ID/static-debian9:nonroot'
+    docker push 'gcr.io/$PROJECT_ID/static-debian10:${COMMIT_SHA}'
+    docker push 'gcr.io/$PROJECT_ID/static-debian10:latest'
+    docker push 'gcr.io/$PROJECT_ID/static-debian10:nonroot'
+    docker push 'gcr.io/$PROJECT_ID/base:${COMMIT_SHA}'
+    docker push 'gcr.io/$PROJECT_ID/base:latest'
+    docker push 'gcr.io/$PROJECT_ID/base:nonroot'
+    docker push 'gcr.io/$PROJECT_ID/base:debug'
+    docker push 'gcr.io/$PROJECT_ID/base:debug-nonroot'
+    docker push 'gcr.io/$PROJECT_ID/base-debian9:${COMMIT_SHA}'
+    docker push 'gcr.io/$PROJECT_ID/base-debian9:latest'
+    docker push 'gcr.io/$PROJECT_ID/base-debian9:nonroot'
+    docker push 'gcr.io/$PROJECT_ID/base-debian9:debug'
+    docker push 'gcr.io/$PROJECT_ID/base-debian9:debug-nonroot'
+    docker push 'gcr.io/$PROJECT_ID/base-debian10:${COMMIT_SHA}'
+    docker push 'gcr.io/$PROJECT_ID/base-debian10:latest'
+    docker push 'gcr.io/$PROJECT_ID/base-debian10:nonroot'
+    docker push 'gcr.io/$PROJECT_ID/base-debian10:debug'
+    docker push 'gcr.io/$PROJECT_ID/base-debian10:debug-nonroot'
+    docker push 'gcr.io/$PROJECT_ID/cc:${COMMIT_SHA}'
+    docker push 'gcr.io/$PROJECT_ID/cc:latest'
+    docker push 'gcr.io/$PROJECT_ID/cc:debug'
+    docker push 'gcr.io/$PROJECT_ID/cc-debian9:${COMMIT_SHA}'
+    docker push 'gcr.io/$PROJECT_ID/cc-debian9:latest'
+    docker push 'gcr.io/$PROJECT_ID/cc-debian9:debug'
+    docker push 'gcr.io/$PROJECT_ID/cc-debian10:${COMMIT_SHA}'
+    docker push 'gcr.io/$PROJECT_ID/cc-debian10:latest'
+    docker push 'gcr.io/$PROJECT_ID/cc-debian10:debug'
+
+- name: docker
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
+
+    # Break it up (see comment at the top)
+    docker push 'gcr.io/$PROJECT_ID/python3:latest'
+    docker push 'gcr.io/$PROJECT_ID/python3:nonroot'
+    docker push 'gcr.io/$PROJECT_ID/python3:debug'
+    docker push 'gcr.io/$PROJECT_ID/python3:debug-nonroot'
+    docker push 'gcr.io/$PROJECT_ID/python3-debian9:latest'
+    docker push 'gcr.io/$PROJECT_ID/python3-debian9:nonroot'
+    docker push 'gcr.io/$PROJECT_ID/python3-debian9:debug'
+    docker push 'gcr.io/$PROJECT_ID/python3-debian9:debug-nonroot'
+    docker push 'gcr.io/$PROJECT_ID/python3-debian10:latest'
+    docker push 'gcr.io/$PROJECT_ID/python3-debian10:nonroot'
+    docker push 'gcr.io/$PROJECT_ID/python3-debian10:debug'
+    docker push 'gcr.io/$PROJECT_ID/python3-debian10:debug-nonroot'
+    docker push 'gcr.io/$PROJECT_ID/python2.7:latest'
+    docker push 'gcr.io/$PROJECT_ID/python2.7:debug'
+    docker push 'gcr.io/$PROJECT_ID/python2.7-debian9:latest'
+    docker push 'gcr.io/$PROJECT_ID/python2.7-debian9:debug'
+    docker push 'gcr.io/$PROJECT_ID/python2.7-debian10:latest'
+    docker push 'gcr.io/$PROJECT_ID/python2.7-debian10:debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs:latest'
+    docker push 'gcr.io/$PROJECT_ID/nodejs:10'
+    docker push 'gcr.io/$PROJECT_ID/nodejs:12'
+    docker push 'gcr.io/$PROJECT_ID/nodejs:14'
+    docker push 'gcr.io/$PROJECT_ID/nodejs:debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs:10-debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs:12-debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs:14-debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian9:latest'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian9:10'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian9:12'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian9:14'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian9:debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian9:10-debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian9:12-debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian9:14-debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian10:latest'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian10:10'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian10:12'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian10:14'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian10:debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian10:10-debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian10:12-debug'
+    docker push 'gcr.io/$PROJECT_ID/nodejs-debian10:14-debug'
+    docker push 'gcr.io/$PROJECT_ID/dotnet:latest'
+    docker push 'gcr.io/$PROJECT_ID/dotnet:debug'
+    docker push 'gcr.io/$PROJECT_ID/dotnet-debian9:latest'
+    docker push 'gcr.io/$PROJECT_ID/dotnet-debian9:debug'
+    docker push 'gcr.io/$PROJECT_ID/dotnet-debian10:latest'
+    docker push 'gcr.io/$PROJECT_ID/dotnet-debian10:debug'
+    docker push 'gcr.io/$PROJECT_ID/dotnet/core/aspnet:latest'
+    docker push 'gcr.io/$PROJECT_ID/dotnet/core/aspnet:3.1'
+    docker push 'gcr.io/$PROJECT_ID/dotnet/core/aspnet:debug'
+    docker push 'gcr.io/$PROJECT_ID/dotnet/core/runtime:latest'
+    docker push 'gcr.io/$PROJECT_ID/dotnet/core/runtime:3.1'
+    docker push 'gcr.io/$PROJECT_ID/dotnet/core/runtime:debug'
+    docker push 'gcr.io/$PROJECT_ID/dotnet/core/sdk:latest'
+    docker push 'gcr.io/$PROJECT_ID/dotnet/core/sdk:3.1'
+    docker push 'gcr.io/$PROJECT_ID/dotnet/core/sdk:debug'
+
+- name: docker
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
+
+    # Publish manifest lists second, after all of the binary material
+    # has been uploaded, so that it is fast.  We want fast because enabling
+    # the experimental features in docker changes ~/.docker/config.json, which
+    # GCB periodically tramples.
+    #
+    # Enable support for 'docker manifest create'
+    # https://docs.docker.com/engine/reference/commandline/manifest_create/
+    sed -i 's/^{/{"experimental": "enabled",/g' ~/.docker/config.json
+
+    docker manifest create gcr.io/$PROJECT_ID/static:nonroot \
+       gcr.io/$PROJECT_ID/static:nonroot-amd64 \
+       gcr.io/$PROJECT_ID/static:nonroot-arm64
+    docker manifest push gcr.io/$PROJECT_ID/static:nonroot
+
+    docker manifest create gcr.io/$PROJECT_ID/static:latest \
+       gcr.io/$PROJECT_ID/static:latest-amd64 \
+       gcr.io/$PROJECT_ID/static:latest-arm64
+    docker manifest push gcr.io/$PROJECT_ID/static:latest


### PR DESCRIPTION
A sample run of this (on my project) produced:
```
    crane manifest gcr.io/mattmoor-knative/static:nonroot
    {
       "schemaVersion": 2,
       "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
       "manifests": [
          {
             "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
             "size": 526,
             "digest": "sha256:2b4a48f7c192111b0ff59633f1ac68f0079b8e8306bf0c5cb55169241ba464c9",
             "platform": {
                "architecture": "amd64",
                "os": "linux"
             }
          },
          {
             "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
             "size": 526,
             "digest": "sha256:9169d04187d456913f000daeddc3fa2c2ae2e27dca5297b697d5c1d6f5b132c7",
             "platform": {
                "architecture": "arm64",
                "os": "linux"
             }
          }
       ]
    }
```

Based on: https://github.com/GoogleContainerTools/distroless/pull/586
Fixes: https://github.com/GoogleContainerTools/distroless/issues/583