### PR TITLE
added common build & publish script

### DIFF
--- a/.github/workflows/publish-debug.yaml
+++ b/.github/workflows/publish-debug.yaml
@@ -1,0 +1,57 @@
+name: publish-debug
+
+on:
+  push:
+    branches: [ 'master' ]
+    paths:
+      - .github/workflows/publish-debug.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install bazelisk
+        run: |
+          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.7.1/bazelisk-linux-amd64"
+          mkdir -p "${GITHUB_WORKSPACE}/bin/"
+          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
+          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
+
+      - name: login ghcr.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: setup
+        run: |
+          bazel build --host_force_python=PY2 //package_manager:dpkg_parser.par
+          sed -i 's/^{/{"experimental": "enabled",/g' ~/.docker/config.json
+
+      - name: build //base:*
+        env:
+          HUB: ghcr.io/${{ github.repository }}
+          LANG: base
+          USERS: root nonroot
+          DISTROS: debian9 debian10
+          TOPICS: base debug static
+          ARCHS: amd64 arm64 s390x
+        run: |
+          ./hack/bazel_run.sh
+          PUSH=1 MANIFEST=1 ./hack/docker_tag_or_push.sh
+
+      - name: build //cc:*
+        env:
+          HUB: ghcr.io/${{ github.repository }}
+          LANG: cc
+          USERS: root nonroot
+          DISTROS: debian9 debian10
+          TOPICS: cc debug
+          ARCHS: amd64 arm64
+        run: |
+          ./hack/bazel_run.sh
+          PUSH=1 MANIFEST=1 ./hack/docker_tag_or_push.sh

--- a/hack/bazel_run.sh
+++ b/hack/bazel_run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LANG=${LANG:-"base"}
+TOPICS=${TOPICS:-"base debug"}
+USERS=${TARGETS:-"root nonroot"}
+ARCHS=${ARCHS:-"amd64 arm64 s390x"}
+DISTROS=${DISTROS:-"debian9 debian10"}
+
+for topic in ${TOPICS}; do
+  for user in ${USERS}; do
+    for distro in ${DISTROS}; do
+      for arch in ${ARCHS}; do
+        bazel run --host_force_python=PY2 //${LANG}:${topic}_${user}_${arch}_${distro}
+      done
+    done
+  done
+done

--- a/hack/docker_tag_or_push.sh
+++ b/hack/docker_tag_or_push.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+LANG=${LANG:-"base"}
+TOPICS=${TOPICS:-"static base debug"}
+USERS=${TARGETS:-"root nonroot"}
+ARCHS=${ARCHS:-"amd64 arm64 s390x"}
+DISTROS=${DISTROS:-"debian9 debian10"}
+
+HUB=${HUB:-localhost:5000/distroless}
+
+COMMIT_SHA=${COMMIT_SHA:-}
+
+PUSH=${PUSH:-}
+MANIFEST=${MANIFEST:-}
+
+docker_tag_or_push() {
+  bazel_image=$1
+  image_name=$2
+  image_tag=$3
+
+
+  if [[ -n ${COMMIT_SHA} ]]; then
+    docker tag ${bazel_image} ${HUB}/${image_name}:${COMMIT_SHA}-${image_tag}
+  fi
+  docker tag ${bazel_image} ${HUB}/${image_name}:${image_tag}
+
+  if [[ -n ${PUSH} ]]; then
+      if [[ -n ${COMMIT_SHA} ]]; then
+        docker push ${HUB}/${image_name}:${COMMIT_SHA}-${image_tag}
+      fi
+      docker push ${HUB}/${image_name}:${image_tag}
+  fi
+}
+
+get_image_base() {
+    image_base=${LANG}
+
+   if [[ ${topic} == "static" ]]; then
+      image_base=static
+   fi
+
+   echo ${image_base}
+}
+
+get_tag_base() {
+   tag_base=latest
+
+  if [[ ${topic} != "static" ]]; then
+    if [[ ${topic} != "${LANG}" ]]; then
+      tag_base=${topic}
+    fi
+  fi
+
+  if [[ ${user} != "root" ]]; then
+     if [[ ${tag_base} != "latest" ]]; then
+        tag_base=${tag_base}-${user}
+     else
+       tag_base=${user}
+     fi
+  fi
+
+  echo ${tag_base}
+}
+
+docker_manifest() {
+  image=$1
+  tag=$2
+  from_images=""
+
+  for arch in ${ARCHS}; do
+    from_images="${from_images} ${HUB}/${image}:${tag}-${arch}"
+  done
+
+  docker manifest create ${HUB}/${image}:${tag} ${from_images}
+  docker manifest push ${HUB}/${image}:${tag}
+}
+
+docker_manifest_all() {
+  image=$1
+  tag=$2
+
+  if [[ -n ${COMMIT_SHA} ]]; then
+    docker_manifest ${image} ${COMMIT_SHA}-${tag}
+  fi
+  docker_manifest ${image} ${tag}
+}
+
+for topic in ${TOPICS}; do
+  for user in ${USERS}; do
+    for distro in ${DISTROS}; do
+      image_base=$(get_image_base)
+      tag_base=$(get_tag_base)
+
+      for arch in ${ARCHS}; do
+        bazel_image=bazel/${LANG}:${topic}_${user}_${arch}_${distro}
+
+        if [[ ${distro} == "debian9" ]]; then
+          docker_tag_or_push ${bazel_image} ${image_base} ${tag_base}-${arch}
+        fi
+        docker_tag_or_push ${bazel_image} ${image_base}-${distro} ${tag_base}-${arch}
+      done
+
+      if [[ ${distro} == "debian9" ]]; then
+        docker_manifest_all ${image_base} ${tag_base}
+      fi
+      docker_manifest_all ${image_base}-${distro} ${tag_base}
+    done
+  done
+done
+
+
+


### PR DESCRIPTION
## workflow

* common build `./hack/build.sh`
  * support switch `USER=${{ matrix.user }} DISTRO=${{ matrix.distro }} ./hack/build.sh ${{ matrix.target }}`
  * with a local registry service for cache bazel docker build for single arch
* use buildx to build and push to `ghcr.io`

## build example
https://github.com/morlay/distroless/runs/1248863511 

published images: https://github.com/morlay?tab=packages
![image](https://user-images.githubusercontent.com/1667873/95890589-95996880-0db6-11eb-962e-f4af969deefe.png)

## setup
https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/enabling-github-container-registry-for-your-organization

* create a persional token for member of GoogleContainerTools https://github.com/settings/tokens/new
   * enable `write:packages` only
* add REPO or ORG secrets `CR_PAT` with the created persional token.