### PR TITLE
Move ppc64le to BASE_ARCHITECTURES

### DIFF
--- a/checksums.bzl
+++ b/checksums.bzl
@@ -58,6 +58,7 @@ SHA256s = {
             "main": "34aef3b450ec40c36b23aa61e8b1d68ed40ee4b496d597364db10a9eadad590e",
             "backports": "37ddcb6e6e96e494f3afd409680dbb0c57ef278453599f5e2a6366b6ead6da63",
             "updates": "2ef877054f0dd43151aed073c66214f217c25cc4a31efa7004a5aafb2442e809",
+            "security": "18c384dc64731dd46dcb3537e7d1b34417392c5e37bf4ce563337bca305f60a4",
         },
         "debian10": {
             "main": "6a60359ca6e3421c2b1ea1a9003f2127cb9e4c8e702a87c0c1074ea212cf171e",

--- a/checksums.bzl
+++ b/checksums.bzl
@@ -2,8 +2,8 @@
 # DO NOT MODIFY THIS FILE DIRECTLY.
 # TO GENERATE THIS RUN: ./updateWorkspaceSnapshots.sh
 
-BASE_ARCHITECTURES = ["amd64", "arm64"]
-ARCHITECTURES = BASE_ARCHITECTURES + ["s390x", "ppc64le"]
+BASE_ARCHITECTURES = ["amd64", "arm64", "ppc64le"]
+ARCHITECTURES = BASE_ARCHITECTURES + ["s390x"]
 
 VERSIONS = [
     ("debian9", "stretch"),

--- a/updateWorkspaceSnapshots.sh
+++ b/updateWorkspaceSnapshots.sh
@@ -94,6 +94,7 @@ SHA256s = {
             "main": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/stretch/main/binary-ppc64el/Packages.gz 2>&1 | sha256sum | cut -d " " -f 1`",
             "backports": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/stretch-backports/main/binary-ppc64el/Packages.gz 2>&1 | sha256sum | cut -d " " -f 1`",
             "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/stretch-updates/main/binary-ppc64el/Packages.gz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/stretch/updates/main/binary-ppc64el/Packages.gz 2>&1 | sha256sum | cut -d " " -f 1`",
         },
         "debian10": {
             "main": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/buster/main/binary-ppc64el/Packages.gz 2>&1 | sha256sum | cut -d " " -f 1`",

--- a/updateWorkspaceSnapshots.sh
+++ b/updateWorkspaceSnapshots.sh
@@ -38,8 +38,8 @@ cat > checksums.bzl <<EOF
 # DO NOT MODIFY THIS FILE DIRECTLY.
 # TO GENERATE THIS RUN: ./updateWorkspaceSnapshots.sh
 
-BASE_ARCHITECTURES = ["amd64", "arm64"]
-ARCHITECTURES = BASE_ARCHITECTURES + ["s390x", "ppc64le"]
+BASE_ARCHITECTURES = ["amd64", "arm64", "ppc64le"]
+ARCHITECTURES = BASE_ARCHITECTURES + ["s390x"]
 
 VERSIONS = [
     ("debian9", "stretch"),


### PR DESCRIPTION
When ppc64le was originally introduced, there was a discussion[1] whether
this new arch should be in BASE_ARCHITECTURES as it does not need any
special handling like s390x

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

[1] https://github.com/GoogleContainerTools/distroless/pull/622/files#r508721244
