### PR TITLE
Disable parallel runs when building package bundles when updating snapshots

### DIFF
--- a/updateWorkspaceSnapshots.sh
+++ b/updateWorkspaceSnapshots.sh
@@ -131,16 +131,16 @@ EOF
 
 bazel clean
 bazel build --host_force_python=PY2 //package_manager:dpkg_parser.par
-bazel build --host_force_python=PY2 @package_bundle_amd64_debian9//file:packages.bzl
-bazel build --host_force_python=PY2 @package_bundle_amd64_debian10//file:packages.bzl
-bazel build --host_force_python=PY2 @package_bundle_arm_debian9//file:packages.bzl
-bazel build --host_force_python=PY2 @package_bundle_arm_debian10//file:packages.bzl
-bazel build --host_force_python=PY2 @package_bundle_arm64_debian9//file:packages.bzl
-bazel build --host_force_python=PY2 @package_bundle_arm64_debian10//file:packages.bzl
-bazel build --host_force_python=PY2 @package_bundle_s390x_debian9//file:packages.bzl
-bazel build --host_force_python=PY2 @package_bundle_s390x_debian10//file:packages.bzl
-bazel build --host_force_python=PY2 @package_bundle_ppc64le_debian9//file:packages.bzl
-bazel build --host_force_python=PY2 @package_bundle_ppc64le_debian10//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_amd64_debian9//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_amd64_debian10//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_arm_debian9//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_arm_debian10//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_arm64_debian9//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_arm64_debian10//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_s390x_debian9//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_s390x_debian10//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_ppc64le_debian9//file:packages.bzl
+bazel build --jobs=1 --host_force_python=PY2 @package_bundle_ppc64le_debian10//file:packages.bzl
 
 # Check if any of the version lock files are updated
 


### PR DESCRIPTION
The daily GitHub Actions workflow to upgrade packages started to fail at some point recently. Disabling parallel runs as we did for Cloud Build:

https://github.com/GoogleContainerTools/distroless/blob/1e4a8bb3ad03f71b572cbcb3bbc25f3fd8d0ff14/cloudbuild.yaml#L20-L33