### PR TITLE
Add signing step to distroless release

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,3 +39,10 @@ steps:
   - PROJECT_ID=${PROJECT_ID}
   - COMMIT_SHA=${COMMIT_SHA}
   entrypoint: ./cloudbuild_docker.sh
+- name: gcr.io/projectsigstore/cosign/ci/cosign:v0.2.0
+  env:
+  - PROJECT_ID=${PROJECT_ID}
+  - COMMIT_SHA=${COMMIT_SHA}
+  entrypoint: sh
+  args:
+  - ./cloudbuild_cosign.sh 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
   - PROJECT_ID=${PROJECT_ID}
   - COMMIT_SHA=${COMMIT_SHA}
   entrypoint: ./cloudbuild_docker.sh
-- name: gcr.io/projectsigstore/cosign/ci/cosign:v0.2.0
+- name: gcr.io/projectsigstore/cosign/ci/cosign:v0.2.0@sha256:b9e72eb217dd93d2144b8143d8c9812e62b32903e790b325116641e89df03e5f
   env:
   - PROJECT_ID=${PROJECT_ID}
   - COMMIT_SHA=${COMMIT_SHA}

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -o errexit
+set -o xtrace
+
+
+export KMS_VAL=gcpkms://projects/$PROJECT_ID/locations/global/keyRings/cosign/cryptoKeys/cosign
+# TODO (priyawadhwa@): Store signatures in distroless repo once we are confident this works
+export COSIGN_REPOSITORY=gcr.io/priya-wadhwa/test
+
+
+# Sign images with cosign
+for distro_suffix in "" -debian9 -debian10; do
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/static${distro_suffix}:nonroot
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/static${distro_suffix}:latest
+
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/base${distro_suffix}:nonroot
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/base${distro_suffix}:latest
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/base${distro_suffix}:debug-nonroot
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/base${distro_suffix}:debug
+
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/cc${distro_suffix}:nonroot
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/cc${distro_suffix}:latest
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/cc${distro_suffix}:debug-nonroot
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/cc${distro_suffix}:debug
+
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python2.7${distro_suffix}:latest
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python2.7${distro_suffix}:debug
+
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python3${distro_suffix}:nonroot
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python3${distro_suffix}:latest
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python3${distro_suffix}:debug-nonroot
+  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python3${distro_suffix}:debug
+done
+
+cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/nodejs:latest
+cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/nodejs:debug

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -8,6 +8,7 @@ export KMS_VAL=gcpkms://projects/$PROJECT_ID/locations/global/keyRings/cosign/cr
 # TODO (priyawadhwa@): Store signatures in distroless repo once we are confident this works
 export COSIGN_REPOSITORY=gcr.io/distroless-signatures
 
+cosign version
 
 # Sign images with cosign
 for distro_suffix in "" -debian9 -debian10; do

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -6,32 +6,32 @@ set -o xtrace
 
 export KMS_VAL=gcpkms://projects/$PROJECT_ID/locations/global/keyRings/cosign/cryptoKeys/cosign
 # TODO (priyawadhwa@): Store signatures in distroless repo once we are confident this works
-export COSIGN_REPOSITORY=gcr.io/priya-wadhwa/test
+export COSIGN_REPOSITORY=gcr.io/distroless-signatures
 
 
 # Sign images with cosign
 for distro_suffix in "" -debian9 -debian10; do
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/static${distro_suffix}:nonroot
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/static${distro_suffix}:latest
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:nonroot
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:latest
 
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/base${distro_suffix}:nonroot
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/base${distro_suffix}:latest
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/base${distro_suffix}:debug-nonroot
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/base${distro_suffix}:debug
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:nonroot
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:latest
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:debug-nonroot
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:debug
 
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/cc${distro_suffix}:nonroot
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/cc${distro_suffix}:latest
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/cc${distro_suffix}:debug-nonroot
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/cc${distro_suffix}:debug
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:nonroot
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:latest
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:debug-nonroot
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:debug
 
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python2.7${distro_suffix}:latest
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python2.7${distro_suffix}:debug
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/python2.7${distro_suffix}:latest
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/python2.7${distro_suffix}:debug
 
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python3${distro_suffix}:nonroot
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python3${distro_suffix}:latest
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python3${distro_suffix}:debug-nonroot
-  cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/python3${distro_suffix}:debug
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:nonroot
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:latest
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:debug-nonroot
+  cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:debug
 done
 
-cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/nodejs:latest
-cosign sign -kms $KMS_VAL -a commit=$COMMIT_SHA gcr.io/$PROJECT_ID/nodejs:debug
+cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/nodejs:latest
+cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/nodejs:debug


### PR DESCRIPTION
Right now signatures will be stored in gcr.io/distroless-signatures -- this will be switched to the main distroless repo once we are confident signing is working as expected!