### PR TITLE
Store all signatures in distroless repo

### DIFF
--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -5,8 +5,6 @@ set -o xtrace
 
 
 export KMS_VAL=gcpkms://projects/$PROJECT_ID/locations/global/keyRings/cosign/cryptoKeys/cosign
-# TODO (priyawadhwa@): Store signatures in distroless repo once we are confident this works
-export COSIGN_REPOSITORY=gcr.io/distroless-signatures
 
 cosign version
 
@@ -35,7 +33,4 @@ for distro_suffix in "" -debian10; do
 done
 
 cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/nodejs:latest
-
-# TODO (priyawadhwa@): remove once all signatures are stored in distroless
-unset COSIGN_REPOSITORY
 cosign sign -kms $KMS_VAL gcr.io/$PROJECT_ID/nodejs:debug


### PR DESCRIPTION
Signing just `gcr.io/distroless/nodejs:debug` worked! It can be verified with:

```
$ cat cosign.pub 
-----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q
OqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==
-----END PUBLIC KEY-----

cosign verify -key cosign.pub gcr.io/distroless/nodejs:debug
```

Now we can go ahead and sign all images
