### PR TITLE
Add correct busybox binary for ppc64le architecture

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -274,11 +274,15 @@ http_file(
     urls = ["https://busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-s390x"],
 )
 
+# To update ppc64le busybox binary (#723)
+# Get the latest commit hash from dist-ppc64le branch of docker-library repo.
+# Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/stable/musl/busybox.tar.xz
+# Update the sha256 value. Since github api doesn't give sha256 value, it can be obtained using sha256sum command.
 http_file(
     name = "busybox_ppc64le",
     executable = True,
-    sha256 = "7f896a2560ef3e2d11438018fef2fbdf8c2a6a2e4b84b1bcbaacc669967532d4",
-    urls = ["https://busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-powerpc64"],
+    sha256 = "469297ea9293df0dcb6c3f8d344eaf9f9b6ec1732696ffe86994f87c3600423b",
+    urls = ["https://github.com/docker-library/busybox/raw/c0125333c4c3dfa4b9e5fd9fe6fbb875242f3613/stable/musl/busybox.tar.xz"],
 )
 
 # Docker rules.

--- a/experimental/busybox/BUILD
+++ b/experimental/busybox/BUILD
@@ -4,11 +4,15 @@ load("//:checksums.bzl", "ARCHITECTURES")
 load(":commands.bzl", "BUSYBOX_COMMANDS")
 
 # This works for all architectures because it is just files.
+# Ppc64le needs special case as there is no direct working binary file available.
 [genrule(
     name = "busybox_" + arch + "_tar",
     srcs = ["@busybox_" + arch + "//file"],
     outs = ["busybox_" + arch + ".tar"],
     cmd = "mkdir busybox; cp $(<) busybox/busybox; cd busybox; \
+           if [[ $(<) == *ppc64le* ]]; then \
+             tar -xf busybox ./bin && mv -f ./bin/busybox . && rm -rf ./bin; \
+           fi; \
            for cmd in %s; do \
              ln -s busybox $$cmd; \
            done; \


### PR DESCRIPTION
This PR is reference to #716. The `ppc64le busybox` binary currently present in the images is wrong and binary from `debian` is old hence using `ppc64le` binary provided by [docker-library/busybox](https://github.com/docker-library/busybox/blob/dist-ppc64le/stable/musl/busybox.tar.xz).

cc: @dlorenc 