### PR TITLE
Update update-deb-package-snapshots.yml

### DIFF
--- a/.github/workflows/update-deb-package-snapshots.yml
+++ b/.github/workflows/update-deb-package-snapshots.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
prepare for limiting scope of github token, it appears all other actions are read only at the moment. After this, we can change the default github token settings to read only