### PR TITLE
Update rules_docker dep to v0.17.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -256,9 +256,9 @@ http_file(
 # Docker rules.
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "198b31d184bbf5f108503a9b7df2a9e40228b63ca60f48a1e6d9959a08015d80",
-    strip_prefix = "rules_docker-afd552062f7cf6c53f636e68c3c011dfe990ebf6",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/afd552062f7cf6c53f636e68c3c011dfe990ebf6.tar.gz"],
+    sha256 = "59d5b42ac315e7eadffa944e86e90c2990110a1c8075f1cd145f487e999d22b3",
+    strip_prefix = "rules_docker-0.17.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.17.0/rules_docker-v0.17.0.tar.gz"],
 )
 
 load(


### PR DESCRIPTION
The [last `rules_docker` dep update](https://github.com/GoogleContainerTools/distroless/pull/728) was to avoid an issue where a transitive dependency resulted in inconsistent GitHub archive downloads and mismatched SHAs when depending on them in Bazel (more info https://github.com/kubernetes/kubernetes/issues/99376).

This change has since been incorporated in a real `rules_docker` release, [v0.17.0](https://github.com/bazelbuild/rules_docker/releases/tag/v0.17.0), which this PR updates to. Depending on a real release seems safer than depending on some random commit in the rules_docker repo.

v0.17.0 currently points to https://github.com/bazelbuild/rules_docker/commit/881e779b5c5b2fad2eeda7ed1f5cb9cbfc10fcdb