### PR TITLE
Working distroless (I think) python3.9 image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -309,6 +309,26 @@ load(
     container_repositories = "repositories",
 )
 
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+)
+
+container_pull(
+    name = "bmdebian10",
+    registry = "index.docker.io",
+    repository = "debian",
+    tag = "latest"
+)
+
+container_pull(
+    name = "bmubuntu",
+    registry = "index.docker.io",
+    repository = "ubuntu",
+    tag = "20.04"
+)
+
+
 container_repositories()
 
 load(

--- a/_helpful_commands.txt
+++ b/_helpful_commands.txt
@@ -1,0 +1,1 @@
+bazel run //experimental/python3:build_python3.9 --cpu=darwin

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -5,6 +5,10 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("//:checksums.bzl", ARCHITECTURES = "BASE_ARCHITECTURES")
 load("//base:base.bzl", "NONROOT")
+load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_extract")
+load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
+load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
+
 
 # distribution-specific deb dependencies
 DISTRO_DEBS = {
@@ -32,12 +36,50 @@ DISTRO_VERSION = {
     "_debian10": "3.7",
 }
 
+container_run_and_extract(
+    name = "build_python",
+    # image = "//base:static_debug_root_amd64_debian10.tar",
+    image = "@bmdebian10//image",
+    commands = ["touch test.txt"],
+    extract_file = "/test.txt"
+)
+
+container_image(
+    name = "bmtestimage",
+    base = "@bmdebian10//image",
+    files = [
+        "build_python/test.txt"
+    ]
+)
+
+download_pkgs(
+    name = "python3.9_package",
+    image_tar = "//experimental/python3:bmtestimage.tar",
+    packages = [
+        "python3.9"
+    ],
+    additional_repos = [
+        "# deb http://snapshot.debian.org/archive/debian/20210621T000000Z sid main",
+        "deb http://deb.debian.org/debian sid main"
+    ]
+)
+
+install_pkgs(
+    name = "build_python3.9",
+    image_tar = "//cc:cc_root_amd64_debian10.tar",
+    installables_tar = "//experimental/python3:python3.9_package.tar",
+    output_image_name = "python3.9_distroless"
+)
+
 [
     container_image(
         name = ("python3" if (not mode) else mode[1:]) + "_root_" + arch + distro_suffix,
         architecture = arch,
         # Based on //cc so that C extensions work properly.
         base = "//cc" + (mode if mode else ":cc") + "_root_" + arch + distro_suffix,
+        files = [
+            "mytestfile.txt"
+        ],
         debs = [
             DISTRO_PACKAGES[arch][distro_suffix]["dash"],
             DISTRO_PACKAGES[arch][distro_suffix]["libbz2-1.0"],

--- a/experimental/python3/mytestfile.txt
+++ b/experimental/python3/mytestfile.txt
@@ -1,0 +1,1 @@
+hello brian


### PR DESCRIPTION
Run the following from the root to get things working
* `bazel build //package_manager:dpkg_parser.par`
* `bazel build //experimental/python3:build_python3.9 --cpu=darwin --sandbox_debug` to build the tar
* `docker image import bazel-bin/experimental/python3/build_python3.9.tar bm:test` to import it into docker

TODO: Add entrypoint of `/usr/bin/python3.9`