### PR TITLE
Preliminary debian11 (bullseye) support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,12 @@ DISTROS = [
     "debian10",
 ]
 
+# temporarily variable used only in static/base, remove when all builds support debian11
+ALL_DISTROS = [
+    "debian10",
+    "debian11",
+]
+
 STATIC = dict({
     "gcr.io/{PROJECT_ID}/static:{COMMIT_SHA}": "//base:static_root_amd64_debian10",
     "gcr.io/{PROJECT_ID}/static-debian10:{COMMIT_SHA}": "//base:static_root_amd64_debian10",
@@ -37,7 +43,7 @@ STATIC.update({
         ("debug", "static_debug", "root"),
         ("debug-nonroot", "static_debug", "nonroot"),
     ]
-    for distro in DISTROS
+    for distro in ALL_DISTROS
 })
 
 BASE = {
@@ -65,7 +71,7 @@ BASE.update({
         ("debug", "debug", "root"),
         ("debug-nonroot", "debug", "nonroot"),
     ]
-    for distro in DISTROS
+    for distro in ALL_DISTROS
 })
 
 CC = {

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,6 +64,21 @@ load(
     )
     for arch in ARCHITECTURES
     for (name, distro) in VERSIONS
+    if "debian10" == name
+    if "security" in SHA256s[arch][name]
+]
+
+# debian11 has a slightly different structure for security on snapshots
+[
+    dpkg_src(
+        name = arch + "_" + name + "_security",
+        package_prefix = "https://snapshot.debian.org/archive/debian-security/{}/".format(DEBIAN_SECURITY_SNAPSHOT),
+        packages_url = "https://snapshot.debian.org/archive/debian-security/{}/dists/{}-security/main/binary-{}/Packages.xz".format(DEBIAN_SECURITY_SNAPSHOT, distro, arch),
+        sha256 = SHA256s[arch][name]["security"],
+    )
+    for arch in ARCHITECTURES
+    for (name, distro) in VERSIONS
+    if "debian11" == name
     if "security" in SHA256s[arch][name]
 ]
 
@@ -79,6 +94,28 @@ load(
     for arch in ARCHITECTURES
     for (name, distro) in VERSIONS
     if "backports" in SHA256s[arch][name]
+]
+
+[
+    dpkg_list(
+        name = "package_bundle_" + arch + "_debian11",
+        # only packages for static and base at the moment
+        packages = [
+            "base-files",
+            "ca-certificates",
+            "libc6",
+            "libssl1.1",
+            "netbase",
+            "openssl",
+            "tzdata",
+        ],
+        sources = [
+            "@" + arch + "_debian11_security//file:Packages.json",
+            "@" + arch + "_debian11_updates//file:Packages.json",
+            "@" + arch + "_debian11//file:Packages.json",
+        ],
+    )
+    for arch in ARCHITECTURES
 ]
 
 [

--- a/base/BUILD
+++ b/base/BUILD
@@ -100,4 +100,5 @@ pkg_tar(
     package_dir = "etc",
 )
 
-[distro_components(suffix) for suffix in DISTRO_SUFFIXES]
+# TODO once all builds use _debian11, remove this
+[distro_components(suffix) for suffix in (DISTRO_SUFFIXES + ["_debian11"])]

--- a/base/distro.bzl
+++ b/base/distro.bzl
@@ -3,41 +3,58 @@ load("@package_bundle_arm_debian10//file:packages.bzl", packages_arm_debian10 = 
 load("@package_bundle_arm64_debian10//file:packages.bzl", packages_arm64_debian10 = "packages")
 load("@package_bundle_s390x_debian10//file:packages.bzl", packages_s390x_debian10 = "packages")
 load("@package_bundle_ppc64le_debian10//file:packages.bzl", packages_ppc64le_debian10 = "packages")
+load("@package_bundle_amd64_debian11//file:packages.bzl", packages_amd64_debian11 = "packages")
+load("@package_bundle_arm_debian11//file:packages.bzl", packages_arm_debian11 = "packages")
+load("@package_bundle_arm64_debian11//file:packages.bzl", packages_arm64_debian11 = "packages")
+load("@package_bundle_s390x_debian11//file:packages.bzl", packages_s390x_debian11 = "packages")
+load("@package_bundle_ppc64le_debian11//file:packages.bzl", packages_ppc64le_debian11 = "packages")
 
+# debian11 is manually added to the list of distro suffixes in base/BUILD
+# update this when debian11 is available for all images
 DISTRO_SUFFIXES = ["_debian10"]
 
 DISTRO_PACKAGES = {
     "amd64": {
         "_debian10": packages_amd64_debian10,
+        "_debian11": packages_amd64_debian11,
     },
     "arm": {
         "_debian10": packages_arm_debian10,
+        "_debian11": packages_arm_debian11,
     },
     "arm64": {
         "_debian10": packages_arm64_debian10,
+        "_debian11": packages_arm64_debian11,
     },
     "s390x": {
         "_debian10": packages_s390x_debian10,
+        "_debian11": packages_s390x_debian11,
     },
     "ppc64le": {
         "_debian10": packages_ppc64le_debian10,
+        "_debian11": packages_ppc64le_debian11,
     },
 }
 
 DISTRO_REPOSITORY = {
     "amd64": {
         "_debian10": "@amd64_debian10",
+        "_debian11": "@amd64_debian11",
     },
     "arm": {
         "_debian10": "@arm_debian10",
+        "_debian11": "@arm_debian11",
     },
     "arm64": {
         "_debian10": "@arm64_debian10",
+        "_debian11": "@arm64_debian11",
     },
     "s390x": {
         "_debian10": "@s390x_debian10",
+        "_debian11": "@s390x_debian11",
     },
     "ppc64le": {
         "_debian10": "@ppc64le_debian10",
+        "_debian11": "@ppc64le_debian11",
     },
 }

--- a/base/testdata/debian11.yaml
+++ b/base/testdata/debian11.yaml
@@ -2,4 +2,4 @@ schemaVersion: "1.0.0"
 fileContentTests:
 - name: 'os-release contents'
   path: '/etc/os-release'
-  expectedContents: ['.*\nVERSION="Debian GNU/Linux 9 \(stretch\)"\n']
+  expectedContents: ['.*\nVERSION="Debian GNU/Linux 11 \(bullseye\)"\n']

--- a/checksums.bzl
+++ b/checksums.bzl
@@ -15,46 +15,72 @@ ARCHITECTURES = BASE_ARCHITECTURES + ["arm", "s390x", "ppc64le"]
 
 VERSIONS = [
     ("debian10", "buster"),
+    ("debian11", "bullseye"),
 ]
 
-DEBIAN_SNAPSHOT = "20210806T092041Z"
+DEBIAN_SNAPSHOT = "20210816T152513Z"
 
-DEBIAN_SECURITY_SNAPSHOT = "20210805T221508Z"
+DEBIAN_SECURITY_SNAPSHOT = "20210816T155958Z"
 
 SHA256s = {
     "amd64": {
         "debian10": {
             "main": "3530cbc6c78b6cadda80c10d949f511abd4a7f33d3492ed17d36a7ecc591a5fd",
             "updates": "d9c9c7624856a0b66caabdc7596d7e1dd98c3795652728f72c153417fa1aa441",
-            "security": "eace8da20f2bcc9c5540b04d09f21e9434c0cf2784c6a67b7f4c8d3fa55b34ba",
+            "security": "ba6070c44de7987f0d93d269fd5958211565d01875d56a3cc49915656ddf04c3",
+        },
+        "debian11": {
+            "main": "2dd487cd20eabf2aaecb3371d26543cfaec0cc7e7dd0846f2aee6b79574374ad",
+            "updates": "0040f94d11d0039505328a90b2ff48968db873e9e7967307631bf40ef5679275",
+            "security": "9913b3c33ab496c0610585ce5e2900c104fce0975798f8817c5f0f416b5e9e39",
         },
     },
     "arm": {
         "debian10": {
             "main": "7f51ba4df1837b4f5b299aa46e533fd006e2dc1b07727e7b32fe87bea9a8be5d",
             "updates": "aee652955e83b5aa1cd4a4b8c48c68f8fce8d22cc7ab07ea51c58e022a10c8a7",
-            "security": "403a7eaa02e79cb2f0bcedbdcc02013efdccf28eda15c671e4ed92c61b8d0bac",
+            "security": "8ca6b7594326ad1b0fdfb609276a5dde0d6bf9a4ed5c53545be8da3d45871183",
+        },
+        "debian11": {
+            "main": "d9dc9d75483fccd9f6f47d6baf1cf3bae166eb8d706de87241fee649d165c0bd",
+            "updates": "0040f94d11d0039505328a90b2ff48968db873e9e7967307631bf40ef5679275",
+            "security": "14dc15d3cc05de3c58cf227d766d69ec56c0b3f3b33ee5fca3ef0ec03a79f81d",
         },
     },
     "arm64": {
         "debian10": {
             "main": "cf63979c9d3f7a411f30f62632626552436a583531a5bdcfc051d63fda8af8a3",
             "updates": "c82c25bcec6b5f2d375e30b8afb8ccf98ef3a2a20dcce1b8e6fa80562bc8195a",
-            "security": "7bd46c2456e14cea0cd1c769539a7ecd39d7df0fb82dd48791825a5e93bb8c29",
+            "security": "cf0682ba36a6a6c450fdc257bb990edeaa823648936eb9400906808cebd85751",
+        },
+        "debian11": {
+            "main": "75d91cc94e87500c63d2808d440ec5197560ba45c5b80e5564c6d60e8ef95140",
+            "updates": "0040f94d11d0039505328a90b2ff48968db873e9e7967307631bf40ef5679275",
+            "security": "bd5397f0574b18e2f4c98607a262fc4e54b6fbbce2049d232fce2694ca37c781",
         },
     },
     "s390x": {
         "debian10": {
             "main": "449258775fd2d7f1a6b30cb5537c25ba9ef88b0b3a41269e61005de6d8a6fb5e",
             "updates": "ab318a9532ec967f496284120c2450c27a15dfad97ea326c0c1698f39b9e80ad",
-            "security": "bce5bda5d51f7ae6e461345e5f0f7242abec769975ff590c7908dc546380b167",
+            "security": "794b1508d5d9e9211d7189cc1e1acf40e95a824f75bd5ab4003e10335d7a76fa",
+        },
+        "debian11": {
+            "main": "0d738ded499cb12ddda2055e225ddeec3f5ec4e002b90af367dd526f71d74716",
+            "updates": "0040f94d11d0039505328a90b2ff48968db873e9e7967307631bf40ef5679275",
+            "security": "a0e21e20308a79b999fe9bda45d2e9e21195b3a752bd0159cce7e78eba1995c8",
         },
     },
     "ppc64le": {
         "debian10": {
             "main": "2d4499fd08d0e2d73bee40c114198ac93098e8d14530e6f5e19a6838f5774b16",
             "updates": "f3d29f5654fc1bfdc4f96f4cd02b8a4507b8869da7ee31a354ef856e227633e0",
-            "security": "9b2b1ebabba4457b07bf3be90ea02d262dbeffbbdad6a81d08a5924747f2700e",
+            "security": "a8eb929a58cbcbae2bfcf930c75a79bc3f6068d26a739d7177f64409aaacf572",
+        },
+        "debian11": {
+            "main": "af2cfa07996e2e5fb8dbb6e904b7f0910fcca79aee7bc25eed21ee0485fd9188",
+            "updates": "0040f94d11d0039505328a90b2ff48968db873e9e7967307631bf40ef5679275",
+            "security": "4b137578c4fcae4caba9c0f92c8857b743b60ff5d04b6f9fc76150e65ea81175",
         },
     },
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,6 +32,12 @@ steps:
     bazel build --jobs=1 @package_bundle_s390x_debian10//file:packages.bzl
     bazel build --jobs=1 @package_bundle_ppc64le_debian10//file:packages.bzl
 
+    bazel build --jobs=1 @package_bundle_amd64_debian11//file:packages.bzl
+    bazel build --jobs=1 @package_bundle_arm_debian11//file:packages.bzl
+    bazel build --jobs=1 @package_bundle_arm64_debian11//file:packages.bzl
+    bazel build --jobs=1 @package_bundle_s390x_debian11//file:packages.bzl
+    bazel build --jobs=1 @package_bundle_ppc64le_debian11//file:packages.bzl
+
     bazel run //:publish
 
 - name: docker

--- a/package_bundle_amd64_debian11.versions
+++ b/package_bundle_amd64_debian11.versions
@@ -1,0 +1,9 @@
+{
+    "base-files": "11.1",
+    "ca-certificates": "20210119",
+    "libc6": "2.31-13",
+    "libssl1.1": "1.1.1k-1",
+    "netbase": "6.3",
+    "openssl": "1.1.1k-1",
+    "tzdata": "2021a-1"
+}

--- a/package_bundle_arm64_debian11.versions
+++ b/package_bundle_arm64_debian11.versions
@@ -1,0 +1,9 @@
+{
+    "base-files": "11.1",
+    "ca-certificates": "20210119",
+    "libc6": "2.31-13",
+    "libssl1.1": "1.1.1k-1",
+    "netbase": "6.3",
+    "openssl": "1.1.1k-1",
+    "tzdata": "2021a-1"
+}

--- a/package_bundle_arm_debian11.versions
+++ b/package_bundle_arm_debian11.versions
@@ -1,0 +1,9 @@
+{
+    "base-files": "11.1",
+    "ca-certificates": "20210119",
+    "libc6": "2.31-13",
+    "libssl1.1": "1.1.1k-1",
+    "netbase": "6.3",
+    "openssl": "1.1.1k-1",
+    "tzdata": "2021a-1"
+}

--- a/package_bundle_ppc64le_debian11.versions
+++ b/package_bundle_ppc64le_debian11.versions
@@ -1,0 +1,9 @@
+{
+    "base-files": "11.1",
+    "ca-certificates": "20210119",
+    "libc6": "2.31-13",
+    "libssl1.1": "1.1.1k-1",
+    "netbase": "6.3",
+    "openssl": "1.1.1k-1",
+    "tzdata": "2021a-1"
+}

--- a/package_bundle_s390x_debian11.versions
+++ b/package_bundle_s390x_debian11.versions
@@ -1,0 +1,9 @@
+{
+    "base-files": "11.1",
+    "ca-certificates": "20210119",
+    "libc6": "2.31-13",
+    "libssl1.1": "1.1.1k-1",
+    "netbase": "6.3",
+    "openssl": "1.1.1k-1",
+    "tzdata": "2021a-1"
+}

--- a/package_manager/util.py
+++ b/package_manager/util.py
@@ -21,6 +21,7 @@ def encode_package_name(s):
     return base64.urlsafe_b64encode(s.encode('utf-8')).decode('utf-8') + ".deb"
 
 DEBIAN_RELEASES = {
+    "bullseye": "11",
     "buster": "10",
     "stretch": "9",
     "jessie": "8",

--- a/updateWorkspaceSnapshots.sh
+++ b/updateWorkspaceSnapshots.sh
@@ -10,6 +10,12 @@ cp package_bundle_arm64_debian10.versions package_bundle_arm64_debian10.versions
 cp package_bundle_s390x_debian10.versions package_bundle_s390x_debian10.versions~
 cp package_bundle_ppc64le_debian10.versions package_bundle_ppc64le_debian10.versions~
 
+cp package_bundle_amd64_debian11.versions package_bundle_amd64_debian11.versions~
+cp package_bundle_arm_debian11.versions package_bundle_arm_debian11.versions~
+cp package_bundle_arm64_debian11.versions package_bundle_arm64_debian11.versions~
+cp package_bundle_s390x_debian11.versions package_bundle_s390x_debian11.versions~
+cp package_bundle_ppc64le_debian11.versions package_bundle_ppc64le_debian11.versions~
+
 YEAR=`date +"%Y"`
 MONTH=`date +"%m"`
 
@@ -48,6 +54,7 @@ ARCHITECTURES = BASE_ARCHITECTURES + ["arm", "s390x", "ppc64le"]
 
 VERSIONS = [
     ("debian10", "buster"),
+    ("debian11", "bullseye"),
 ]
 
 DEBIAN_SNAPSHOT = "$DEBIAN_SNAPSHOT"
@@ -61,12 +68,22 @@ SHA256s = {
             "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/buster-updates/main/binary-amd64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
             "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/buster/updates/main/binary-amd64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
         },
+        "debian11": {
+            "main": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye/main/binary-amd64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye-updates/main/binary-amd64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/bullseye-security/main/binary-amd64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+        },
     },
     "arm": {
         "debian10": {
             "main": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/buster/main/binary-armhf/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
             "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/buster-updates/main/binary-armhf/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
             "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/buster/updates/main/binary-armhf/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+        },
+        "debian11": {
+            "main": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye/main/binary-armhf/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye-updates/main/binary-armhf/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/bullseye-security/main/binary-armhf/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
         },
     },
     "arm64": {
@@ -75,6 +92,11 @@ SHA256s = {
             "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/buster-updates/main/binary-arm64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
             "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/buster/updates/main/binary-arm64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
         },
+        "debian11": {
+            "main": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye/main/binary-arm64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye-updates/main/binary-arm64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/bullseye-security/main/binary-arm64/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+        },
     },
     "s390x": {
         "debian10": {
@@ -82,12 +104,22 @@ SHA256s = {
             "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/buster-updates/main/binary-s390x/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
             "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/buster/updates/main/binary-s390x/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
         },
+        "debian11": {
+            "main": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye/main/binary-s390x/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye-updates/main/binary-s390x/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/bullseye-security/main/binary-s390x/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+        },
     },
     "ppc64le": {
         "debian10": {
             "main": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/buster/main/binary-ppc64el/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
             "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/buster-updates/main/binary-ppc64el/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
             "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/buster/updates/main/binary-ppc64el/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+        },
+        "debian11": {
+            "main": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye/main/binary-ppc64el/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "updates": "`curl -s https://snapshot.debian.org/archive/debian/$DEBIAN_SNAPSHOT/dists/bullseye-updates/main/binary-ppc64el/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
+            "security": "`curl -s https://snapshot.debian.org/archive/debian-security/$DEBIAN_SECURITY_SNAPSHOT/dists/bullseye-security/main/binary-ppc64el/Packages.xz 2>&1 | sha256sum | cut -d " " -f 1`",
         },
     },
 }
@@ -103,13 +135,24 @@ bazel build @package_bundle_arm64_debian10//file:packages.bzl
 bazel build @package_bundle_s390x_debian10//file:packages.bzl
 bazel build @package_bundle_ppc64le_debian10//file:packages.bzl
 
+bazel build @package_bundle_amd64_debian11//file:packages.bzl
+bazel build @package_bundle_arm_debian11//file:packages.bzl
+bazel build @package_bundle_arm64_debian11//file:packages.bzl
+bazel build @package_bundle_s390x_debian11//file:packages.bzl
+bazel build @package_bundle_ppc64le_debian11//file:packages.bzl
+
 # Check if any of the version lock files are updated
 
 if diff -w package_bundle_amd64_debian10.versions package_bundle_amd64_debian10.versions~ &&
 	diff -w package_bundle_arm_debian10.versions package_bundle_arm_debian10.versions~ &&
 	diff -w package_bundle_arm64_debian10.versions package_bundle_arm64_debian10.versions~ &&
 	diff -w package_bundle_s390x_debian10.versions package_bundle_s390x_debian10.versions~ &&
-	diff -w package_bundle_ppc64le_debian10.versions package_bundle_ppc64le_debian10.versions~; then
+	diff -w package_bundle_ppc64le_debian10.versions package_bundle_ppc64le_debian10.versions~ &&
+  diff -w package_bundle_amd64_debian11.versions package_bundle_amd64_debian11.versions~ &&
+	diff -w package_bundle_arm_debian11.versions package_bundle_arm_debian11.versions~ &&
+	diff -w package_bundle_arm64_debian11.versions package_bundle_arm64_debian11.versions~ &&
+	diff -w package_bundle_s390x_debian11.versions package_bundle_s390x_debian11.versions~ &&
+	diff -w package_bundle_ppc64le_debian11.versions package_bundle_ppc64le_debian11.versions~; then
     echo "No changes detected to package_bundle versions."
     mv checksums.bzl~ checksums.bzl
     mv package_bundle_amd64_debian10.versions~ package_bundle_amd64_debian10.versions
@@ -117,6 +160,11 @@ if diff -w package_bundle_amd64_debian10.versions package_bundle_amd64_debian10.
     mv package_bundle_arm64_debian10.versions~ package_bundle_arm64_debian10.versions
     mv package_bundle_s390x_debian10.versions~ package_bundle_s390x_debian10.versions
     mv package_bundle_ppc64le_debian10.versions~ package_bundle_ppc64le_debian10.versions
+    mv package_bundle_amd64_debian11.versions~ package_bundle_amd64_debian11.versions
+    mv package_bundle_arm_debian11.versions~ package_bundle_arm_debian11.versions
+    mv package_bundle_arm64_debian11.versions~ package_bundle_arm64_debian11.versions
+    mv package_bundle_s390x_debian11.versions~ package_bundle_s390x_debian11.versions
+    mv package_bundle_ppc64le_debian11.versions~ package_bundle_ppc64le_debian11.versions
 else
     echo "Changes detected to package_bundle version files. Please update snapshots."
     rm *~


### PR DESCRIPTION
Adds images for:

static-debian11:latest-amd64
static-debian11:nonroot-amd64
static-debian11:debug-amd64
static-debian11:debug-nonroot-amd64
static-debian11:latest-arm64
static-debian11:nonroot-arm64
static-debian11:debug-arm64
static-debian11:debug-nonroot-arm64
static-debian11:latest-arm
static-debian11:nonroot-arm
static-debian11:debug-arm
static-debian11:debug-nonroot-arm
static-debian11:latest-s390x
static-debian11:nonroot-s390x
static-debian11:debug-s390x
static-debian11:debug-nonroot-s390x
static-debian11:latest-ppc64le
static-debian11:nonroot-ppc64le
static-debian11:debug-ppc64le
static-debian11:debug-nonroot-ppc64le
base-debian11:latest-amd64
base-debian11:nonroot-amd64
base-debian11:debug-amd64
base-debian11:debug-nonroot-amd64
base-debian11:latest-arm64
base-debian11:nonroot-arm64
base-debian11:debug-arm64
base-debian11:debug-nonroot-arm64
base-debian11:latest-arm
base-debian11:nonroot-arm
base-debian11:debug-arm
base-debian11:debug-nonroot-arm
base-debian11:latest-s390x
base-debian11:nonroot-s390x
base-debian11:debug-s390x
base-debian11:debug-nonroot-s390x
base-debian11:latest-ppc64le
base-debian11:nonroot-ppc64le
base-debian11:debug-ppc64le
base-debian11:debug-nonroot-ppc64le

Signed-off-by: Appu Goundan <appu@google.com>