### PR TITLE
package_manager dpkg_parser: Use /usr/bin/env python3

### DIFF
--- a/package_manager/BUILD
+++ b/package_manager/BUILD
@@ -1,5 +1,6 @@
 load("@subpar//:subpar.bzl", "par_binary")
 
+# Requires python3 for lzma system library
 par_binary(
     name = "dpkg_parser",
     srcs = [
@@ -8,9 +9,10 @@ par_binary(
     ],
     compiler_args = [
         "--interpreter",
-        "/usr/bin/env python",
+        "/usr/bin/env python3",
     ],
     main = "dpkg_parser.py",
+    python_version = "PY3",
     deps = [
         ":parse_metadata",
         ":util",


### PR DESCRIPTION
The dpkg_parser.py file imports the lzma system package, which only
exists in Python 3. On my system (Debian 10), the default "python"
is still Python 2. As a result, the built dpkg_parser.par does not
execute. Update the interpreter to use "python3" explicitly.

The python_version attribute does nothing at the moment, but it seems
to me that is likely a bug in the subpar bazel rules. Let's set it
since that seems to be the documented way to change the Python
version for a py_binary.