### PR TITLE
python2.7/python3: rm testdata/debian9.yaml

### DIFF
--- a/experimental/python2.7/testdata/debian9.yaml
+++ b/experimental/python2.7/testdata/debian9.yaml
@@ -1,5 +1,0 @@
-schemaVersion: "1.0.0"
-commandTests:
-  - name: version
-    command: ["/usr/bin/python2.7", "--version"]
-    expectedError: ["Python 2.7.13"]

--- a/experimental/python3/testdata/debian9.yaml
+++ b/experimental/python3/testdata/debian9.yaml
@@ -1,8 +1,0 @@
-schemaVersion: "1.0.0"
-commandTests:
-  - name: version
-    command: ["/usr/bin/python3", "--version"]
-    expectedOutput: ["Python 3.5.3"]
-  - name: symlink
-    command: ["/usr/bin/python", "--version"]
-    expectedOutput: ["Python 3.5.3"]


### PR DESCRIPTION
This test configuration is no longer used now that Debian 9 is no
longer supported.