### PR TITLE
examples/cc: Add C++ example program

### DIFF
--- a/examples/cc/BUILD
+++ b/examples/cc/BUILD
@@ -3,12 +3,18 @@
 # repository code at any time.
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
 load("//base:distro.bzl", "DISTRO_SUFFIXES")
+load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 cc_binary(
     name = "hello",
     srcs = ["hello.c"],
+)
+
+cc_binary(
+    name = "hello_cc",
+    srcs = ["hello_cc.cc"],
 )
 
 [cc_image(
@@ -17,13 +23,28 @@ cc_binary(
     binary = ":hello",
 ) for distro_suffix in DISTRO_SUFFIXES]
 
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+[cc_image(
+    name = "hello_cc" + distro_suffix,
+    base = "//cc:cc_root_amd64" + distro_suffix,
+    binary = ":hello_cc",
+) for distro_suffix in DISTRO_SUFFIXES]
 
 [container_test(
     name = "hello" + distro_suffix + "_test",
     size = "small",
     configs = ["testdata/hello.yaml"],
     image = ":hello" + distro_suffix,
+    tags = [
+        "amd64",
+        "manual",
+    ],
+) for distro_suffix in DISTRO_SUFFIXES]
+
+[container_test(
+    name = "hello_cc" + distro_suffix + "_test",
+    size = "small",
+    configs = ["testdata/hello_cc.yaml"],
+    image = ":hello_cc" + distro_suffix,
     tags = [
         "amd64",
         "manual",

--- a/examples/cc/hello.c
+++ b/examples/cc/hello.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
 int main() {
-   printf("Hello from distroless!");
+   printf("Hello from distroless C!\n");
    return 0;
 }

--- a/examples/cc/hello_cc.cc
+++ b/examples/cc/hello_cc.cc
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+   std::cout << "Hello from distroless C++!" << std::endl;
+   return 0;
+}

--- a/examples/cc/testdata/hello.yaml
+++ b/examples/cc/testdata/hello.yaml
@@ -2,4 +2,4 @@ schemaVersion: "1.0.0"
 commandTests:
   - name: hello
     command: ['/app/examples/cc/hello']
-    expectedOutput: ['Hello from distroless!']
+    expectedOutput: ['Hello from distroless C!']

--- a/examples/cc/testdata/hello_cc.yaml
+++ b/examples/cc/testdata/hello_cc.yaml
@@ -1,0 +1,5 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: hello_cc
+    command: ['/app/examples/cc/hello_cc']
+    expectedOutput: ['Hello from distroless C\+\+!']


### PR DESCRIPTION
While this example is nearly identical to the existing C program,
this serves as a test to make sure the //cc image contains the
right shared libraries for C++ programs. The exact libraries are
changing with the Debian 11 release, so this helped verify that
change.