### PR TITLE
cc: Add debian11 support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -108,6 +108,11 @@ load(
             "netbase",
             "openssl",
             "tzdata",
+
+            # c++
+            "libgcc-s1",
+            "libgomp1",
+            "libstdc++6",
         ],
         sources = [
             "@" + arch + "_debian11_security//file:Packages.json",

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -4,6 +4,16 @@ load("//base:distro.bzl", "DISTRO_PACKAGES", "DISTRO_SUFFIXES")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("//:checksums.bzl", "ARCHITECTURES")
 
+# distribution-specific deb dependencies
+DISTRO_DEBS = {
+    "_debian10": [
+        "libgcc1",
+    ],
+    "_debian11": [
+        "libgcc-s1",
+    ],
+}
+
 # An image for C/C++ programs
 [
     container_image(
@@ -11,10 +21,9 @@ load("//:checksums.bzl", "ARCHITECTURES")
         architecture = arch,
         base = "//base" + (mode if mode else ":base") + "_" + user + "_" + arch + distro_suffix,
         debs = [
-            DISTRO_PACKAGES[arch][distro_suffix]["libgcc1"],
             DISTRO_PACKAGES[arch][distro_suffix]["libgomp1"],
             DISTRO_PACKAGES[arch][distro_suffix]["libstdc++6"],
-        ],
+        ] + [DISTRO_PACKAGES[arch][distro_suffix][deb] for deb in DISTRO_DEBS[distro_suffix]],
     )
     for mode in [
         "",
@@ -25,5 +34,5 @@ load("//:checksums.bzl", "ARCHITECTURES")
         "root",
         "nonroot",
     ]
-    for distro_suffix in DISTRO_SUFFIXES
+    for distro_suffix in DISTRO_SUFFIXES + ["_debian11"]
 ]


### PR DESCRIPTION
This has not been carefully tested, but //examples/cc does work.
This is necessary for Python images.