### PR TITLE
Make sure we are signing every image built

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -39,12 +39,16 @@ steps:
     bazel build --jobs=1 @package_bundle_ppc64le_debian11//file:packages.bzl
 
     bazel run //:publish
+    bazel build all.tar
 
 - name: docker
   env:
   - PROJECT_ID=${PROJECT_ID}
   - COMMIT_SHA=${COMMIT_SHA}
   entrypoint: ./cloudbuild_docker.sh
+
+- name: ubuntu
+  entrypoint: ./cloudbuild_jq.sh
 
 - name: gcr.io/projectsigstore/cosign:v0.6.0@sha256:2303322158802ec0452758578ac80801a3754ee9cb19c128fc5d1b2ec32fa2d2
   env:

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -14,3 +14,33 @@ while IFS= read -r line; do
   cosign sign -key $KMS_VAL $line
 done < images
 
+# Sign 'latest' images with cosign
+for distro_suffix in "" -debian10 -debian11; do
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:nonroot
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:latest
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:debug-nonroot
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:debug
+
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:nonroot
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:latest
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:debug-nonroot
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:debug
+done
+
+for distro_suffix in "" -debian10; do
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:nonroot
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:latest
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:debug-nonroot
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:debug
+
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python2.7${distro_suffix}:latest
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python2.7${distro_suffix}:debug
+
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:nonroot
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:latest
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:debug-nonroot
+  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:debug
+done
+
+cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/nodejs:latest
+cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/nodejs:debug

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -8,33 +8,9 @@ export KMS_VAL=gcpkms://projects/$PROJECT_ID/locations/global/keyRings/cosign/cr
 
 cosign version
 
-# Sign images with cosign
-for distro_suffix in "" -debian10 -debian11; do
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:debug-nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:debug
+# Get all images from 'images' file
 
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:debug-nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:debug
-done
+while IFS= read -r line; do
+  cosign sign -key $KMS_VAL $line
+done < images
 
-for distro_suffix in "" -debian10; do
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:debug-nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:debug
-
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python2.7${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python2.7${distro_suffix}:debug
-
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:debug-nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:debug
-done
-
-cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/nodejs:latest
-cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/nodejs:debug

--- a/cloudbuild_jq.sh
+++ b/cloudbuild_jq.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -o errexit
+set -o xtrace
+
+apt-get update
+apt-get install -y jq
+
+cd bazel-bin
+tar -xvf all.tar
+cd ..
+
+# Get a list of all images
+cat bazel-bin/manifest.json | jq -r [".[] | .RepoTags"] | jq 'flatten' | jq  .[] | sed 's/\"//g' > images
+cat images


### PR DESCRIPTION
Instead of hardcoding the images to sign, read all the images that were built from the manifest and sign them -- no images should be left behind now! 

I tried on my own project and this worked! There were 241 images to sign 😮 

fixes https://github.com/GoogleContainerTools/distroless/issues/803