### PR TITLE
Update rules_docker

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -298,9 +298,9 @@ http_file(
 # Docker rules.
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "59d5b42ac315e7eadffa944e86e90c2990110a1c8075f1cd145f487e999d22b3",
-    strip_prefix = "rules_docker-0.17.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.17.0/rules_docker-v0.17.0.tar.gz"],
+    sha256 = "1f4e59843b61981a96835dc4ac377ad4da9f8c334ebe5e0bb3f58f80c09735f4",
+    strip_prefix = "rules_docker-0.19.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.19.0/rules_docker-v0.19.0.tar.gz"],
 )
 
 load(

--- a/base/testdata/base.yaml
+++ b/base/testdata/base.yaml
@@ -34,6 +34,9 @@ fileExistenceTests:
 - name: nonroot-homedir
   path: '/home/nonroot'
   shouldExist: true
+- name: dpkg-status.d
+  path: '/var/lib/dpkg/status.d/libc6'
+  shouldExist: true
 fileContentTests:
 - name: 'known users'
   path: '/etc/passwd'


### PR DESCRIPTION
Fixes issue where package names in status.d were base64 encoded

fixes #787 

Signed-off-by: Appu Goundan <appu@google.com>