### PR TITLE
Add Tekton task for generating provenance 

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -60,3 +60,22 @@ steps:
   entrypoint: sh
   args:
   - ./cloudbuild_cosign.sh 
+
+# Start task in k8s to generate provenance
+- name: gcr.io/cloud-builders/gcloud
+  args:
+  - container
+  - clusters
+  - get-credentials
+  - provenance
+  - --zone=us-central1-c
+  - --project=distroless
+
+- name: gcr.io/tekton-releases/dogfooding/tkn@sha256:f69a02ef099d8915e9e4ea1b74e43b7a9309fc97cf23cb457ebf191e73491677
+  args:
+  - task
+  - start
+  - -f=provenance/provenance-task.yaml
+  - --param
+  - CHAINS-GIT_COMMIT=${COMMIT_SHA}
+  - --use-param-defaults

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -63,19 +63,20 @@ steps:
 
 # Start task in k8s to generate provenance
 - name: gcr.io/cloud-builders/gcloud
+  entrypoint: sh
   args:
-  - container
-  - clusters
-  - get-credentials
-  - provenance
-  - --zone=us-central1-c
-  - --project=distroless
+  - -c
+  - |
+    #!/bin/sh
+    set -o errexit
+    set -o xtrace
 
-- name: gcr.io/tekton-releases/dogfooding/tkn@sha256:f69a02ef099d8915e9e4ea1b74e43b7a9309fc97cf23cb457ebf191e73491677
-  args:
-  - task
-  - start
-  - -f=provenance/provenance-task.yaml
-  - --param
-  - CHAINS-GIT_COMMIT=${COMMIT_SHA}
-  - --use-param-defaults
+    gcloud container clusters get-credentials provenance --zone=us-central1-c --project=distroless
+    
+    # Install tkn
+    curl -Lo tkn_0.20.0_Linux_arm64.tar.gz  https://github.com/tektoncd/cli/releases/download/v0.20.0/tkn_0.20.0_Linux_x86_64.tar.gz
+    tar -xvzf tkn_0.20.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
+
+    # Start provenance task
+    tkn task start -f=provenance/provenance-task.yaml --param CHAINS-GIT_COMMIT=${COMMIT_SHA} --use-param-defaults
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -65,6 +65,8 @@ steps:
 
 # Start task in k8s to generate provenance
 - name: gcr.io/cloud-builders/gcloud
+  env:
+  - TKN_VERSION=0.20.0
   entrypoint: sh
   args:
   - -c
@@ -73,11 +75,11 @@ steps:
     set -o errexit
     set -o xtrace
 
-    gcloud container clusters get-credentials provenance --zone=us-central1-c --project=distroless
+    gcloud container clusters get-credentials provenance --zone=us-central1-c --project=${PROJECT_ID}
     
     # Install tkn
-    curl -Lo tkn_0.20.0_Linux_arm64.tar.gz  https://github.com/tektoncd/cli/releases/download/v0.20.0/tkn_0.20.0_Linux_x86_64.tar.gz
-    tar -xvzf tkn_0.20.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
+    curl -Lo tkn_${TKN_VERSION}_Linux_arm64.tar.gz  https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz
+    tar -xvzf tkn_${TKN_VERSION}_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
 
     # Start provenance task
     tkn task start -f=provenance/provenance-task.yaml --param CHAINS-GIT_COMMIT=${COMMIT_SHA} --use-param-defaults

--- a/provenance/provenance-task.yaml
+++ b/provenance/provenance-task.yaml
@@ -1,0 +1,77 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: distroless-provenance
+  annotations:
+    description: |
+      Takes in the distroless repo as an input and builds & pushes distroless images.
+spec:
+  results:
+    - name: IMAGES
+  params:
+    - name: PROJECT_ID
+      default: distroless
+    - name: CHAINS-GIT_COMMIT
+    - name: CHAINS-GIT_URL
+      default: https://github.com/GoogleContainerTools/distroless
+  steps:
+    - name: bazel
+      image: gcr.io/cloud-marketplace-containers/google/bazel:3.4.1
+      env:
+      - name: PROJECT_ID
+        value: $(params.PROJECT_ID)
+      - name: REGISTRY
+        value: insecure-registry.default.svc.cluster.local:5000
+      - name: COMMIT_SHA
+        value: $(params.CHAINS-GIT_COMMIT)
+      script: |
+        #!/bin/sh
+        set -ex
+
+        git clone $(params.CHAINS-GIT_URL)
+        cd distroless
+        git checkout $(params.CHAINS-GIT_COMMIT)
+
+        # Make sure python points to python3
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 0
+
+        bazel build //package_manager:dpkg_parser.par
+
+        bazel build --jobs=1 @package_bundle_amd64_debian10//file:packages.bzl
+        bazel build --jobs=1 @package_bundle_arm_debian10//file:packages.bzl
+        bazel build --jobs=1 @package_bundle_arm64_debian10//file:packages.bzl
+        bazel build --jobs=1 @package_bundle_s390x_debian10//file:packages.bzl
+        bazel build --jobs=1 @package_bundle_ppc64le_debian10//file:packages.bzl
+        bazel build --jobs=1 @package_bundle_amd64_debian11//file:packages.bzl
+        bazel build --jobs=1 @package_bundle_arm_debian11//file:packages.bzl
+        bazel build --jobs=1 @package_bundle_arm64_debian11//file:packages.bzl
+        bazel build --jobs=1 @package_bundle_s390x_debian11//file:packages.bzl
+        bazel build --jobs=1 @package_bundle_ppc64le_debian11//file:packages.bzl
+
+        bazel run //:publish
+
+    - name: crane
+      image: golang:1.16
+      env:
+      - name: REGISTRY
+        value: insecure-registry.default.svc.cluster.local:5000
+      - name: COMMIT_SHA
+        value: $(params.CHAINS-GIT_COMMIT)
+      - name: PROVENANCE_IMAGES
+        value: base static cc
+      - name: PROVENANCE_TAGS
+        value: latest-amd64 $(params.CHAINS-GIT_COMMIT)
+      script: |
+        #!/bin/sh
+        set -ex
+
+        go install github.com/google/go-containerregistry/cmd/crane@latest
+
+        for image in $PROVENANCE_IMAGES 
+        do 
+            for tag in $PROVENANCE_TAGS
+            do
+                digest=$(crane digest $REGISTRY/$(params.PROJECT_ID)/$image:$tag)
+                echo gcr.io/$(params.PROJECT_ID)/$image@$digest, >> $(results.IMAGES.path)
+            done
+        done

--- a/provenance/provenance-task.yaml
+++ b/provenance/provenance-task.yaml
@@ -3,6 +3,7 @@ kind: Task
 metadata:
   name: distroless-provenance
   annotations:
+    chains.tekton.dev/transparency-upload: "true"
     description: |
       Takes in the distroless repo as an input and builds & pushes distroless images.
 spec:
@@ -10,9 +11,12 @@ spec:
     - name: IMAGES
   params:
     - name: PROJECT_ID
+      type: string
       default: distroless
     - name: CHAINS-GIT_COMMIT
+      type: string
     - name: CHAINS-GIT_URL
+      type: string
       default: https://github.com/GoogleContainerTools/distroless
   steps:
     - name: bazel


### PR DESCRIPTION
Adds a task which:
1. pulls in the distroless repo at the specified commit
2. builds the images and pushes to an insecure registry to the cluster
3. gets the digests for six distroless images, and saves them in the IMAGES result

This six images will be picked up by Tekton Chains to generate provenance

If this works, we can definitely add in more images. we can probably have up to 30 per Task before we hit the maximum size for Tekton results.