### PR TITLE
Add libharfbuzz0b to java image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -162,6 +162,10 @@ load(
             "openjdk-11-jre-headless",
             "openjdk-11-jdk-headless",
             "libc-bin",
+            "libgraphite2-3",
+            "libharfbuzz0b",
+            "libglib2.0-0",
+            "libpcre3",
 
             #python
             "dash",

--- a/java/BUILD
+++ b/java/BUILD
@@ -32,6 +32,10 @@ USERS = [
             DISTRO_PACKAGES["amd64"][distro_suffix]["libexpat1"],
             DISTRO_PACKAGES["amd64"][distro_suffix]["libfontconfig1"],
             DISTRO_PACKAGES["amd64"][distro_suffix]["libuuid1"],
+            DISTRO_PACKAGES["amd64"][distro_suffix]["libgraphite2-3"],
+            DISTRO_PACKAGES["amd64"][distro_suffix]["libharfbuzz0b"],
+            DISTRO_PACKAGES["amd64"][distro_suffix]["libglib2.0-0"],
+            DISTRO_PACKAGES["amd64"][distro_suffix]["libpcre3"],
         ],
         env = {"LANG": "C.UTF-8"},
         tars = [


### PR DESCRIPTION
I'm experiencing the issue #729 . 

This change will add the libharfbuzz0b and dependencies related to Debian 10-based Java image.

I've tested this locally and it seems to have fixed the issue.