### PR TITLE
Refactor the cosign script.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -57,6 +57,8 @@ steps:
   - PROJECT_ID=${PROJECT_ID}
   - COMMIT_SHA=${COMMIT_SHA}
   - REGISTRY=gcr.io
+  - KMS_VAL=gcpkms://projects/${PROJECT_ID}/locations/global/keyRings/cosign/cryptoKeys/cosign
   entrypoint: sh
   args:
-  - ./cloudbuild_cosign.sh 
+  - -c
+  - ./cloudbuild_cosign.sh -key $KMS_VAL

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -4,43 +4,41 @@ set -o errexit
 set -o xtrace
 
 
-export KMS_VAL=gcpkms://projects/$PROJECT_ID/locations/global/keyRings/cosign/cryptoKeys/cosign
-
 cosign version
 
 # Get all images from 'images' file
 
 while IFS= read -r line; do
-  cosign sign -key $KMS_VAL $line
+  cosign sign "$@" $line
 done < images
 
 # Sign 'latest' images with cosign
 for distro_suffix in "" -debian10 -debian11; do
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:debug-nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/static${distro_suffix}:debug
+  cosign sign "$@" gcr.io/$PROJECT_ID/static${distro_suffix}:nonroot
+  cosign sign "$@" gcr.io/$PROJECT_ID/static${distro_suffix}:latest
+  cosign sign "$@" gcr.io/$PROJECT_ID/static${distro_suffix}:debug-nonroot
+  cosign sign "$@" gcr.io/$PROJECT_ID/static${distro_suffix}:debug
 
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:debug-nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/base${distro_suffix}:debug
+  cosign sign "$@" gcr.io/$PROJECT_ID/base${distro_suffix}:nonroot
+  cosign sign "$@" gcr.io/$PROJECT_ID/base${distro_suffix}:latest
+  cosign sign "$@" gcr.io/$PROJECT_ID/base${distro_suffix}:debug-nonroot
+  cosign sign "$@" gcr.io/$PROJECT_ID/base${distro_suffix}:debug
 done
 
 for distro_suffix in "" -debian10; do
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:debug-nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/cc${distro_suffix}:debug
+  cosign sign "$@" gcr.io/$PROJECT_ID/cc${distro_suffix}:nonroot
+  cosign sign "$@" gcr.io/$PROJECT_ID/cc${distro_suffix}:latest
+  cosign sign "$@" gcr.io/$PROJECT_ID/cc${distro_suffix}:debug-nonroot
+  cosign sign "$@" gcr.io/$PROJECT_ID/cc${distro_suffix}:debug
 
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python2.7${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python2.7${distro_suffix}:debug
+  cosign sign "$@" gcr.io/$PROJECT_ID/python2.7${distro_suffix}:latest
+  cosign sign "$@" gcr.io/$PROJECT_ID/python2.7${distro_suffix}:debug
 
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:latest
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:debug-nonroot
-  cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/python3${distro_suffix}:debug
+  cosign sign "$@" gcr.io/$PROJECT_ID/python3${distro_suffix}:nonroot
+  cosign sign "$@" gcr.io/$PROJECT_ID/python3${distro_suffix}:latest
+  cosign sign "$@" gcr.io/$PROJECT_ID/python3${distro_suffix}:debug-nonroot
+  cosign sign "$@" gcr.io/$PROJECT_ID/python3${distro_suffix}:debug
 done
 
-cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/nodejs:latest
-cosign sign -key $KMS_VAL gcr.io/$PROJECT_ID/nodejs:debug
+cosign sign "$@" gcr.io/$PROJECT_ID/nodejs:latest
+cosign sign "$@" gcr.io/$PROJECT_ID/nodejs:debug


### PR DESCRIPTION
This refactors the cosign script for distroless, so that the arguments are passed through from `cloudbuild.yaml`, and shifts where `-key ...` is passed to be in `cloudbuild.yaml`.

This is preparation to start *also* signing the distroless images with a "keyless" flow, once https://github.com/sigstore/cosign/pull/652 lands and cosign 1.2 cuts.

