### PR TITLE
Fix user-defined substitutions and shell for cloudbuild_cosign script

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -57,16 +57,13 @@ steps:
   - PROJECT_ID=${PROJECT_ID}
   - COMMIT_SHA=${COMMIT_SHA}
   - REGISTRY=gcr.io
-  - KMS_VAL=gcpkms://projects/${PROJECT_ID}/locations/global/keyRings/cosign/cryptoKeys/cosign
   entrypoint: sh
   args:
   - -c
-  - ./cloudbuild_cosign.sh -key $KMS_VAL
+  - ./cloudbuild_cosign.sh -key $_KMS_VAL
 
 # Start task in k8s to generate provenance
 - name: gcr.io/cloud-builders/gcloud
-  env:
-  - TKN_VERSION=0.20.0
   entrypoint: sh
   args:
   - -c
@@ -78,8 +75,8 @@ steps:
     gcloud container clusters get-credentials provenance --zone=us-central1-c --project=${PROJECT_ID}
     
     # Install tkn
-    curl -Lo tkn_${TKN_VERSION}_Linux_arm64.tar.gz  https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_Linux_x86_64.tar.gz
-    tar -xvzf tkn_${TKN_VERSION}_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
+    curl -Lo tkn_${_TKN_VERSION}_Linux_arm64.tar.gz  https://github.com/tektoncd/cli/releases/download/v${_TKN_VERSION}/tkn_${_TKN_VERSION}_Linux_x86_64.tar.gz
+    tar -xvzf tkn_${_TKN_VERSION}_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
 
     # Start provenance task
     tkn task start -f=provenance/provenance-task.yaml --param CHAINS-GIT_COMMIT=${COMMIT_SHA} --use-param-defaults

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/busybox/sh
 
 set -o errexit
 set -o xtrace


### PR DESCRIPTION
User defined env vars have to [start with an underscore](https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values) and need to be specified on the trigger itself, so I updated the trigger with the value for `_KMS_VAL` and `_TKN_VERSION`

`cloudbuild_cosign.sh` also wasn't being run because the wrong shell was specified 

Builds have been broken since #823, hopefully this should fix it (cc @mattmoor )