### PR TITLE
Add nodejs debian11 support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -144,6 +144,14 @@ NODEJS = {
     "{REGISTRY}/{PROJECT_ID}/nodejs-debian10:12-debug": "//nodejs:nodejs12_debug_amd64_debian10",
     "{REGISTRY}/{PROJECT_ID}/nodejs-debian10:14-debug": "//nodejs:nodejs14_debug_amd64_debian10",
     "{REGISTRY}/{PROJECT_ID}/nodejs-debian10:16-debug": "//nodejs:nodejs16_debug_amd64_debian10",
+    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:latest": "//nodejs:nodejs14_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:debug": "//nodejs:nodejs14_debug_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:12": "//nodejs:nodejs12_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:14": "//nodejs:nodejs14_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:16": "//nodejs:nodejs16_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:12-debug": "//nodejs:nodejs12_debug_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:14-debug": "//nodejs:nodejs14_debug_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:16-debug": "//nodejs:nodejs16_debug_amd64_debian11",
 }
 
 JAVA = {

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -1,6 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("//base:distro.bzl", "DISTRO_SUFFIXES")
 load("//:checksums.bzl", ARCHITECTURES = "BASE_ARCHITECTURES")
 
@@ -20,5 +21,62 @@ NODEJS_MAJOR_VERISONS = ("12", "14", "16")
     ]
     for major_version in NODEJS_MAJOR_VERISONS
     for arch in ARCHITECTURES
-    for distro_suffix in DISTRO_SUFFIXES
+    for distro_suffix in DISTRO_SUFFIXES + ["_debian11"]
+]
+
+[
+    container_test(
+        name = "nodejs" + major_version + ("" if (not mode) else mode) + "_" + arch + distro_suffix + "_test",
+        configs = ["testdata/nodejs" + major_version + ".yaml"],
+        image = "nodejs" + major_version + ("" if (not mode) else mode) + "_" + arch + distro_suffix,
+        tags = [
+            arch,
+            "manual",
+        ],
+    )
+    for mode in [
+        "",
+        "_debug",
+    ]
+    for major_version in NODEJS_MAJOR_VERISONS
+    for arch in ARCHITECTURES
+    for distro_suffix in DISTRO_SUFFIXES + ["_debian11"]
+]
+
+exports_files([
+    "testdata/check_certificate.js",
+])
+
+[
+    container_image(
+        name = "check_certificate_nodejs" + major_version + ("" if (not mode) else mode) + "_" + arch + distro_suffix,
+        base = "nodejs" + major_version + ("" if (not mode) else mode) + "_" + arch + distro_suffix,
+        files = ["testdata/check_certificate.js"],
+    )
+    for mode in [
+        "",
+        "_debug",
+    ]
+    for major_version in NODEJS_MAJOR_VERISONS
+    for arch in ARCHITECTURES
+    for distro_suffix in DISTRO_SUFFIXES + ["_debian11"]
+]
+
+[
+    container_test(
+        name = "check_certificate_nodejs" + major_version + ("" if (not mode) else mode) + "_" + arch + distro_suffix + "_test",
+        configs = ["testdata/check_certificate.yaml"],
+        image = "check_certificate_nodejs" + major_version + ("" if (not mode) else mode) + "_" + arch + distro_suffix,
+        tags = [
+            arch,
+            "manual",
+        ],
+    )
+    for mode in [
+        "",
+        "_debug",
+    ]
+    for major_version in NODEJS_MAJOR_VERISONS
+    for arch in ARCHITECTURES
+    for distro_suffix in DISTRO_SUFFIXES + ["_debian11"]
 ]

--- a/nodejs/testdata/check_certificate.js
+++ b/nodejs/testdata/check_certificate.js
@@ -1,0 +1,13 @@
+const https = require('https')
+const options = {
+  hostname: 'www.google.com',
+  port: 443,
+  path: '/',
+  method: 'GET'
+}
+
+const req = https.request(options, res => {
+  console.log(`statusCode: ${res.statusCode}`)
+})
+
+req.end()

--- a/nodejs/testdata/check_certificate.yaml
+++ b/nodejs/testdata/check_certificate.yaml
@@ -1,0 +1,6 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: nodejs
+    command: "/nodejs/bin/node" 
+    args: ["/check_certificate.js"]
+    expectedOutput: ['statusCode: 200']

--- a/nodejs/testdata/nodejs12.yaml
+++ b/nodejs/testdata/nodejs12.yaml
@@ -1,0 +1,6 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: nodejs
+    command: "/nodejs/bin/node"
+    args: ["--version"]
+    expectedOutput: ['v12.22.6']

--- a/nodejs/testdata/nodejs14.yaml
+++ b/nodejs/testdata/nodejs14.yaml
@@ -1,0 +1,6 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: nodejs
+    command: "/nodejs/bin/node"
+    args: ["--version"]
+    expectedOutput: ['v14.17.6']

--- a/nodejs/testdata/nodejs16.yaml
+++ b/nodejs/testdata/nodejs16.yaml
@@ -1,0 +1,6 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: nodejs
+    command: "/nodejs/bin/node"
+    args: ["--version"]
+    expectedOutput: ['v16.9.1']


### PR DESCRIPTION
def: debian 11 support #844 

- Add debian11 variants
- Does not change default to point at debian11
- Add test for nodejs images