### PR TITLE
Increase cloudbuild timeout to 60m

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 2700s  # 45 minutes
+timeout: 3600s  # 60 minutes
 
 options:
   machineType: N1_HIGHCPU_8


### PR DESCRIPTION
We recently had a build fail at the 45 min mark in the middle of step 4 -- signing with a GCB service account. The builds that pass are taking around 40 minutes. Increasing to 60m should be enough for all builds to pass.