### PR TITLE
Add java17 (not published)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,8 +27,8 @@ jobs:
         bazel build --curses=no //package_manager:dpkg_parser.par
         bazel build --curses=no //...
         bazel test --curses=no --test_output=errors //...
-        # Ignore java8 and experimental targets, which might not pass.
+        # Ignore experimental targets, which might not pass.
         # TODO: Fix or remove these exceptions.
-        targets=$(bazel query 'attr("tags", "'amd64'", "//...")' | grep -v java8 | grep -v experimental)
+        targets=$(bazel query 'attr("tags", "'amd64'", "//...")' | grep -v experimental)
         bazel build --curses=no ${targets}
         bazel test --curses=no --test_output=errors ${targets}

--- a/BUILD
+++ b/BUILD
@@ -233,3 +233,16 @@ container_push(
     # https://github.com/bazelbuild/rules_docker/issues/525
     sequential = True,
 )
+
+# do not publish these until java 17 is out of preview, leave them here for preview testing
+JAVA17 = {
+    "distroless/java:17": "//java:java17_root_debian11",
+    "distroless/java:17-nonroot": "//java:java17_nonroot_debian11",
+    "distroless/java:17-debug": "//java:java17_debug_root_debian11",
+    "distroless/java:17-debug-nonroot": "//java:java17_debug_nonroot_debian11",
+}
+
+container_bundle(
+    name = "java17_preview",
+    images = JAVA17,
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,6 +132,8 @@ load(
             "libuuid1",
             "openjdk-11-jdk-headless",
             "openjdk-11-jre-headless",
+            "openjdk-17-jdk-headless",  # 11 and 17 should share the same "base"
+            "openjdk-17-jre-headless",
             "zlib1g",
 
             # python

--- a/checksums.bzl
+++ b/checksums.bzl
@@ -18,69 +18,69 @@ VERSIONS = [
     ("debian11", "bullseye"),
 ]
 
-DEBIAN_SNAPSHOT = "20210929T025048Z"
+DEBIAN_SNAPSHOT = "20211006T084856Z"
 
-DEBIAN_SECURITY_SNAPSHOT = "20210927T122233Z"
+DEBIAN_SECURITY_SNAPSHOT = "20211004T085236Z"
 
 SHA256s = {
     "amd64": {
         "debian10": {
             "main": "3530cbc6c78b6cadda80c10d949f511abd4a7f33d3492ed17d36a7ecc591a5fd",
             "updates": "0936f32b2bfc20b4f2e4e3fb8c03853a4ec1b50e9b150f66a7c34a609b30ec00",
-            "security": "e204130d94c1e6cc3caea81f4037c1c28b9a6ed31455ac157feb542f51e0dd30",
+            "security": "97bd385abee73080997b140dea8397e8672385f25ecff49bb970c303084eeb93",
         },
         "debian11": {
             "main": "2dd487cd20eabf2aaecb3371d26543cfaec0cc7e7dd0846f2aee6b79574374ad",
             "updates": "942f49679a50f19ca65a74ae199c161659d505b9aca8bdfa62dfe9af74d468fd",
-            "security": "88602074042c9f5f527edb4aae20a78f3471688c6f8dab3618fc318cacf15079",
+            "security": "286655faf6380ce415772064ffbaea62eadf4ea3f644a060da0d5ee1c728e097",
         },
     },
     "arm": {
         "debian10": {
             "main": "7f51ba4df1837b4f5b299aa46e533fd006e2dc1b07727e7b32fe87bea9a8be5d",
             "updates": "30eae05b1a48151ac8d9210bdaa63416bae1164edbc1877c1c45ba6194665122",
-            "security": "b77439adc7fba4aa2f87a4ad2276b7ad2d0cd15a2cfb3c8d50ce8b9a7af9181c",
+            "security": "56bd10a5f7bb813462eea28d38135488bcb6bb523784aeb44f6b9631cc746a56",
         },
         "debian11": {
             "main": "d9dc9d75483fccd9f6f47d6baf1cf3bae166eb8d706de87241fee649d165c0bd",
             "updates": "ba68fa6b90160b2f964c1cf9955f5845f321e4aa1ce098e8e8caa6828f83da5a",
-            "security": "3cafdb8dacd6a613a6c6307c08b743414a1192f15144e8fe220e7e7f1efe9b24",
+            "security": "47654d4882b391ca00c68d2766a0504e0ab25814f70ce4c457c5aeb65833f646",
         },
     },
     "arm64": {
         "debian10": {
             "main": "cf63979c9d3f7a411f30f62632626552436a583531a5bdcfc051d63fda8af8a3",
             "updates": "d73fa59a15e7e781c789bde00002bbafbbfc9b307dc86c80cffce0ec1786f04b",
-            "security": "4d6506ce3919a3472f79042c01e38ded258802c3a938284f2faa4887db822e02",
+            "security": "cf0c24c33b13faf6c4f3d6dbffea19279b0c950dbeb6521ca728948ce9c45fb1",
         },
         "debian11": {
             "main": "75d91cc94e87500c63d2808d440ec5197560ba45c5b80e5564c6d60e8ef95140",
             "updates": "1c3c0eb34677b8529760a3d53c7e591bcb3a1d35625db7638c3050e43972108b",
-            "security": "be576442c5606937986b564fd36c5945a617506481cf2f96ddc2297c40b479ff",
+            "security": "27897879f6ef66f533287d68282dd589532a2805f549560392513e40135fe3db",
         },
     },
     "s390x": {
         "debian10": {
             "main": "449258775fd2d7f1a6b30cb5537c25ba9ef88b0b3a41269e61005de6d8a6fb5e",
             "updates": "ca4232219b6fd6db324d022e29398c3abd20b20a74f616a78c5e2237f0f84fb2",
-            "security": "e4b825e44535e1978c0cd463a9d41ca7d2cfe41484b09ea8310557850cc3541e",
+            "security": "fadea813ffac01144ba8beac508eb8fd4e40cd08eaf2534de37a4c3fc9bb5327",
         },
         "debian11": {
             "main": "0d738ded499cb12ddda2055e225ddeec3f5ec4e002b90af367dd526f71d74716",
             "updates": "03b9831e0b68693fdc0843d8e50617f763c7e41bda306b5f8d77cf2133dc1664",
-            "security": "fd11d6bab73dc2fb92bb8ad6b0ca695505a7b7df9c86f650f21ede33043f4d96",
+            "security": "5014df6aa36a057ff741675e17d4598ce3cbdc4f1baa7755e403528029c9554c",
         },
     },
     "ppc64le": {
         "debian10": {
             "main": "2d4499fd08d0e2d73bee40c114198ac93098e8d14530e6f5e19a6838f5774b16",
             "updates": "b4c2d0eb902ac275a144f2fca96129608dda37ec2d531a7271692731aefdaa51",
-            "security": "9258f0ee93a7043367873786f1fc86d8277ffa4eab354fc12407614d3da9b258",
+            "security": "d7d5028468fc70dc035d064e1bd6f6dda4fd4e34e02f0d58a6515fded7af215b",
         },
         "debian11": {
             "main": "af2cfa07996e2e5fb8dbb6e904b7f0910fcca79aee7bc25eed21ee0485fd9188",
             "updates": "dc4d120c139ee18e95593e3b625cc04aa842b5727d78f38a3f2fa2957318047d",
-            "security": "fbf6d1b0ca25e52be4356ba986148dd21e0b26e27baf2e96973846b60f280cde",
+            "security": "3e307fda15ca234b1423675c909930a104828da8817380476c57a24cc2a41385",
         },
     },
 }

--- a/java/BUILD
+++ b/java/BUILD
@@ -19,6 +19,12 @@ USERS = [
     "nonroot",
 ]
 
+VERSION_PAIRS = [
+    ("11", "_debian10"),
+    ("11", "_debian11"),
+    ("17", "_debian11"),
+]
+
 EXTRA_DEBS = {
     "_debian10": [],
     "_debian11": [
@@ -62,35 +68,41 @@ EXTRA_DEBS = {
 
 [
     container_image(
-        name = rule_name + "_" + user + distro_suffix,
-        base = ":java_base" + ("_debug" if ("debug" in rule_name) else "") + "_" + user + distro_suffix,
-        debs = [DISTRO_PACKAGES["amd64"][distro_suffix][deb] for deb in java_debs],
+        name = "java" + java_version + "_" + user + distro_suffix,
+        base = ":java_base_" + user + distro_suffix,
+        debs = [DISTRO_PACKAGES["amd64"][distro_suffix]["openjdk-" + java_version + "-jre-headless"]],
         # We expect users to use:
         # cmd = ["/path/to/deploy.jar", "--option1", ...]
         entrypoint = [
             "/usr/bin/java",
             "-jar",
         ],
-        env = {"JAVA_VERSION": jre_ver(DISTRO_VERSIONS[distro_suffix][java_debs[0]])},
-        symlinks = {"/usr/bin/java": java_executable_path},
+        env = {"JAVA_VERSION": jre_ver(DISTRO_VERSIONS[distro_suffix]["openjdk-" + java_version + "-jre-headless"])},
+        symlinks = {"/usr/bin/java": "/usr/lib/jvm/java-" + java_version + "-openjdk-amd64/bin/java"},
     )
-    for (rule_name, java_debs, java_executable_path) in [
-        (
-            "java11",
-            ["openjdk-11-jre-headless"],
-            "/usr/lib/jvm/java-11-openjdk-amd64/bin/java",
-        ),
-        (
-            "java11_debug",
-            [
-                "openjdk-11-jre-headless",
-                "openjdk-11-jdk-headless",
-            ],
-            "/usr/lib/jvm/java-11-openjdk-amd64/bin/java",
-        ),
-    ]
+    for (java_version, distro_suffix) in VERSION_PAIRS
     for user in USERS
-    for distro_suffix in DISTRO_SUFFIXES
+]
+
+[
+    container_image(
+        name = "java" + java_version + "_debug_" + user + distro_suffix,
+        base = ":java_base_debug_" + user + distro_suffix,
+        debs = [
+            DISTRO_PACKAGES["amd64"][distro_suffix]["openjdk-" + java_version + "-jre-headless"],
+            DISTRO_PACKAGES["amd64"][distro_suffix]["openjdk-" + java_version + "-jdk-headless"],
+        ],
+        # We expect users to use:
+        # cmd = ["/path/to/deploy.jar", "--option1", ...]
+        entrypoint = [
+            "/usr/bin/java",
+            "-jar",
+        ],
+        env = {"JAVA_VERSION": jre_ver(DISTRO_VERSIONS[distro_suffix]["openjdk-" + java_version + "-jre-headless"])},
+        symlinks = {"/usr/bin/java": "/usr/lib/jvm/java-" + java_version + "-openjdk-amd64/bin/java"},
+    )
+    for (java_version, distro_suffix) in VERSION_PAIRS
+    for user in USERS
 ]
 
 [
@@ -113,30 +125,30 @@ EXTRA_DEBS = {
 
 [
     container_test(
-        name = "java11_" + user + distro_suffix + "_test",
-        configs = ["testdata/java11" + distro_suffix + ".yaml"],
-        image = ":java11_" + user + distro_suffix,
+        name = "java" + java_version + "_" + user + distro_suffix + "_test",
+        configs = ["testdata/java" + java_version + distro_suffix + ".yaml"],
+        image = ":java" + java_version + "_" + user + distro_suffix,
         tags = [
             "amd64",
             "manual",
         ],
     )
     for user in USERS
-    for distro_suffix in DISTRO_SUFFIXES
+    for (java_version, distro_suffix) in VERSION_PAIRS
 ]
 
 [
     container_test(
-        name = "java11_debug_" + user + distro_suffix + "_test",
-        configs = ["testdata/java11_debug" + distro_suffix + ".yaml"],
-        image = ":java11_debug_" + user + distro_suffix,
+        name = "java" + java_version + "_debug_" + user + distro_suffix + "_test",
+        configs = ["testdata/java" + java_version + "_debug" + distro_suffix + ".yaml"],
+        image = ":java" + java_version + "_debug_" + user + distro_suffix,
         tags = [
             "amd64",
             "manual",
         ],
     )
     for user in USERS
-    for distro_suffix in DISTRO_SUFFIXES
+    for (java_version, distro_suffix) in VERSION_PAIRS
 ]
 
 RULE_NAMES = [
@@ -144,6 +156,8 @@ RULE_NAMES = [
     "java11_nonroot_debian10",
     "java11_root_debian11",
     "java11_nonroot_debian11",
+    "java17_root_debian11",
+    "java17_nonroot_debian11",
 ]
 
 [

--- a/java/jre_ver.bzl
+++ b/java/jre_ver.bzl
@@ -1,11 +1,13 @@
 def jre_ver(version):
     """Extract JRE version from a Debian openjdk package.
       Debian packages versions are of the form:
-         openjdk-8-jre*: 8u171-b11-1~deb9u1
          openjdk-11-jre*: 11.0.1+13-2~bpo9+1
+         openjdk-17-jre*: 17~19-1 or in the future 17+35-1
     """
-    if version.startswith("8u"):
-        return version.split("-")[0]
     if version.startswith("11."):
         return version.split("+")[0]
+
+    # TODO switch to "+" when version changes to 17+35-1, update comment above
+    if version.startswith("17"):
+        return version.split("~")[0]
     fail("unrecognized openjdk package version: " + version)

--- a/java/testdata/java17_debian11.yaml
+++ b/java/testdata/java17_debian11.yaml
@@ -1,0 +1,27 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: java
+    command: "/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "17-ea"']
+  - name: java-symlink
+    command: "/usr/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "17-ea"']
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: no-busybox
+    path: "/busybox/sh"
+    shouldExist: false
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+  - name: no-javac
+    path: "/usr/lib/jvm/java-17-openjdk-amd64/bin/javac"
+    shouldExist: false
+metadataTest:
+  env:
+    - key: 'JAVA_VERSION'
+      value: '17'

--- a/java/testdata/java17_debug_debian11.yaml
+++ b/java/testdata/java17_debug_debian11.yaml
@@ -1,0 +1,28 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: java
+    command: "/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "17-ea"']
+  - name: java-symlink
+    command: "/usr/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "17-ea"']
+  - name: javac
+    command: "/usr/lib/jvm/java-17-openjdk-amd64/bin/javac"
+    args: ["-version"]
+    expectedOutput: ['javac 17-ea']
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: busybox
+    path: "/busybox/sh"
+    shouldExist: true
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+metadataTest:
+  env:
+    - key: 'JAVA_VERSION'
+      value: '17'

--- a/java/testdata/java17_nonroot_debian11_certs.yaml
+++ b/java/testdata/java17_nonroot_debian11_certs.yaml
@@ -1,0 +1,9 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: connect_to_https_google_com
+    # This is a bit ugly because structure tests can't test the default entrypoint yet.
+    command: ["/usr/bin/java",
+              "-cp",
+              "/app/distroless/java/check_certs_java17_nonroot_debian11.binary.jar:/app/distroless/java/check_certs_java17_nonroot_debian10.binary",
+              "testdata.CheckCerts"]
+    expectedOutput: ['Successfully connected: 200']

--- a/java/testdata/java17_nonroot_debian11_encoding.yaml
+++ b/java/testdata/java17_nonroot_debian11_encoding.yaml
@@ -1,0 +1,12 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: check_encoding
+    command: ["/usr/bin/java",
+              "-cp",
+              "/app/distroless/java/check_encoding_java17_nonroot_debian11.binary.jar:/app/distroless/java/check_encoding_java17_nonroot_debian10.binary",
+              "testdata.CheckEncoding"]
+    expectedOutput: ['LANG=C.UTF-8',
+                     'Locale.getDefault\(\)=en',
+                     'Charset.defaultCharset\(\)=UTF-8',
+                     'file.encoding=UTF-8',
+                     'sun.jnu.encoding=UTF-8']

--- a/java/testdata/java17_nonroot_debian11_libharfbuzz.yaml
+++ b/java/testdata/java17_nonroot_debian11_libharfbuzz.yaml
@@ -1,0 +1,8 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: check_libharfbuzz
+    command: ["/usr/bin/java",
+              "-cp",
+              "/app/distroless/java/check_libharfbuzz_java17_nonroot_debian11.binary.jar:/app/distroless/java/check_libharfbuzz_java17_nonroot_debian10.binary",
+              "testdata.CheckLibharfbuzz"]
+    expectedOutput: ['^\d+ fonts available']

--- a/java/testdata/java17_root_debian11_certs.yaml
+++ b/java/testdata/java17_root_debian11_certs.yaml
@@ -1,0 +1,9 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: connect_to_https_google_com
+    # This is a bit ugly because structure tests can't test the default entrypoint yet.
+    command: ["/usr/bin/java",
+              "-cp",
+              "/app/distroless/java/check_certs_java17_root_debian11.binary.jar:/app/distroless/java/check_certs_java17_root_debian10.binary",
+              "testdata.CheckCerts"]
+    expectedOutput: ['Successfully connected: 200']

--- a/java/testdata/java17_root_debian11_encoding.yaml
+++ b/java/testdata/java17_root_debian11_encoding.yaml
@@ -1,0 +1,12 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: check_encoding
+    command: ["/usr/bin/java",
+              "-cp",
+              "/app/distroless/java/check_encoding_java17_root_debian11.binary.jar:/app/distroless/java/check_encoding_java17_root_debian10.binary",
+              "testdata.CheckEncoding"]
+    expectedOutput: ['LANG=C.UTF-8',
+                     'Locale.getDefault\(\)=en',
+                     'Charset.defaultCharset\(\)=UTF-8',
+                     'file.encoding=UTF-8',
+                     'sun.jnu.encoding=UTF-8']

--- a/java/testdata/java17_root_debian11_libharfbuzz.yaml
+++ b/java/testdata/java17_root_debian11_libharfbuzz.yaml
@@ -1,0 +1,8 @@
+schemaVersion: "1.0.0"
+commandTests:
+  - name: check_libharfbuzz
+    command: ["/usr/bin/java",
+              "-cp",
+              "/app/distroless/java/check_libharfbuzz_java17_root_debian11.binary.jar:/app/distroless/java/check_libharfbuzz_java17_root_debian10.binary",
+              "testdata.CheckLibharfbuzz"]
+    expectedOutput: ['^\d+ fonts available']

--- a/package_bundle_amd64_debian11.versions
+++ b/package_bundle_amd64_debian11.versions
@@ -45,6 +45,8 @@
     "netbase": "6.3",
     "openjdk-11-jdk-headless": "11.0.12+7-2",
     "openjdk-11-jre-headless": "11.0.12+7-2",
+    "openjdk-17-jdk-headless": "17~19-1",
+    "openjdk-17-jre-headless": "17~19-1",
     "openssl": "1.1.1k-1+deb11u1",
     "python3-distutils": "3.9.2-1",
     "python3.9-minimal": "3.9.2-1",

--- a/package_bundle_arm64_debian11.versions
+++ b/package_bundle_arm64_debian11.versions
@@ -45,6 +45,8 @@
     "netbase": "6.3",
     "openjdk-11-jdk-headless": "11.0.12+7-2",
     "openjdk-11-jre-headless": "11.0.12+7-2",
+    "openjdk-17-jdk-headless": "17~19-1",
+    "openjdk-17-jre-headless": "17~19-1",
     "openssl": "1.1.1k-1+deb11u1",
     "python3-distutils": "3.9.2-1",
     "python3.9-minimal": "3.9.2-1",

--- a/package_bundle_arm_debian11.versions
+++ b/package_bundle_arm_debian11.versions
@@ -45,6 +45,8 @@
     "netbase": "6.3",
     "openjdk-11-jdk-headless": "11.0.12+7-2",
     "openjdk-11-jre-headless": "11.0.12+7-2",
+    "openjdk-17-jdk-headless": "17~19-1",
+    "openjdk-17-jre-headless": "17~19-1",
     "openssl": "1.1.1k-1+deb11u1",
     "python3-distutils": "3.9.2-1",
     "python3.9-minimal": "3.9.2-1",

--- a/package_bundle_ppc64le_debian11.versions
+++ b/package_bundle_ppc64le_debian11.versions
@@ -45,6 +45,8 @@
     "netbase": "6.3",
     "openjdk-11-jdk-headless": "11.0.12+7-2",
     "openjdk-11-jre-headless": "11.0.12+7-2",
+    "openjdk-17-jdk-headless": "17~19-1",
+    "openjdk-17-jre-headless": "17~19-1",
     "openssl": "1.1.1k-1+deb11u1",
     "python3-distutils": "3.9.2-1",
     "python3.9-minimal": "3.9.2-1",

--- a/package_bundle_s390x_debian11.versions
+++ b/package_bundle_s390x_debian11.versions
@@ -45,6 +45,8 @@
     "netbase": "6.3",
     "openjdk-11-jdk-headless": "11.0.12+7-2",
     "openjdk-11-jre-headless": "11.0.12+7-2",
+    "openjdk-17-jdk-headless": "17~19-1",
+    "openjdk-17-jre-headless": "17~19-1",
     "openssl": "1.1.1k-1+deb11u1",
     "python3-distutils": "3.9.2-1",
     "python3.9-minimal": "3.9.2-1",


### PR DESCRIPTION
- Fundamentally the only difference between the 11 and 17 dependencies
  is libatomic1 which is not available for amd64 anyway
- https://packages.debian.org/bullseye/openjdk-17-jre-headless
- https://packages.debian.org/bullseye/openjdk-11-jre-headless

Signed-off-by: Appu Goundan <appu@google.com>