### PR TITLE
WORKSPACE: Update rules_go to 0.24; bazel_gazelle to 0.22

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,13 +2,14 @@ workspace(name = "distroless")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "a8d6b1b354d371a646d2f7927319974e0f9e52f73a2452d2b3877118169eb6bb",
+    sha256 = "e0015762cdeb5a2a9c48f96fb079c6a98e001d44ec23ad4fa2ca27208c5be4fb",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.23.3/rules_go-v0.23.3.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.23.3/rules_go-v0.23.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.14/rules_go-v0.24.14.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.14/rules_go-v0.24.14.tar.gz",
     ],
 )
 
@@ -17,6 +18,22 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains()
+
+# bazel_gazelle is used by rules_docker, and needs to be updated to override the very old version
+# used in that workspace. We must use a version compatible with our version of rules_go. See:
+# https://github.com/bazelbuild/bazel-gazelle#compatibility-with-rules-go
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "222e49f034ca7a1d1231422cdb67066b885819885c356673cb1f72f748a3c9d4",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
 
 load("//package_manager:dpkg.bzl", "dpkg_list", "dpkg_src")
 load(


### PR DESCRIPTION
This is the most recent version of io_bazel_rules_go that supports
Bazel 3.4 (the current version in .bazelversion). This required
updating bazel_gazelle to a compatible release, since that is used by
rules_docker.

rules_go >= 0.26 requires Bazel >= 3.5, which is newer than the
current version (3.4.1). This means we need rules_go <= 0.25.

The most recent version of bazel_gazelle that supports
rules_go <= 0.25 is 0.22, which supports the range [0.20, 0.24]
inclusive. This means rules_go=0.24 and bazel_gazelle=0.22 are the
most recent versions we can use without upgrading Bazel.

We probably should eventually upgrade Bazel to the 4.0 LTS release,
but I thought it would be worth upgrading our third-party
dependencies first. The release notes for rules_go 0.25 claims that
version should support Bazel 4.0. We may need to update everything
together when we do that update.
See: https://github.com/bazelbuild/rules_go/releases/tag/v0.25.0