### PR TITLE
WORKSPACE: Update io_bazel_rules_docker to latest v0.20.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -348,9 +348,9 @@ http_file(
 # Docker rules.
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "1f4e59843b61981a96835dc4ac377ad4da9f8c334ebe5e0bb3f58f80c09735f4",
-    strip_prefix = "rules_docker-0.19.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.19.0/rules_docker-v0.19.0.tar.gz"],
+    sha256 = "92779d3445e7bdc79b961030b996cb0c91820ade7ffa7edca69273f404b085d5",
+    strip_prefix = "rules_docker-0.20.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.20.0/rules_docker-v0.20.0.tar.gz"],
 )
 
 load(


### PR DESCRIPTION
This was released on 2021-10-11. It seems like a reasonable idea to
track the latest upstream release, but I am not aware of any specific
reason or issue to require this update.

https://github.com/bazelbuild/rules_docker/releases/tag/v0.20.0