### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+- package-ecosystem: "github-actions"
+  directory: "/"


### PR DESCRIPTION
Enable dependabot for version upgrades and tracking security vulnerabilities.

The setting has to be turned on https://github.com/GoogleContainerTools/distroless/security other than merging this.