### PR TITLE
update to use distroless static vs base, including qualified guidance

### DIFF
--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:latest as build-env
 
 WORKDIR /go/src/app
-COPY main.go .
+COPY *.go .
 
 RUN go mod init
 RUN go get -d -v ./...

--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -8,13 +8,8 @@ RUN go get -d -v ./...
 RUN go vet -v
 RUN go test -v
 
-# Details on when to utilize cgo: 
-#   https://pkg.go.dev/cmd/cgo  
 RUN CGO_ENABLED=0 go build -o /go/bin/app
 
-# Details on when to use Distroless Base vs Static:
-#   https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md
-#FROM gcr.io/distroless/base
 FROM gcr.io/distroless/static
 
 COPY --from=build-env /go/bin/app /

--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -6,7 +6,7 @@ COPY main.go .
 RUN go mod init
 RUN go get -d -v ./...
 
-# Detaails on when to utilize cgo: 
+# Details on when to utilize cgo: 
 #   https://pkg.go.dev/cmd/cgo  
 RUN CGO_ENABLED=0 go build -o /go/bin/app
 

--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -1,12 +1,22 @@
-FROM golang:1.12 as build-env
+FROM golang:latest as build-env
+
+LABEL NAME distroless-go-example
+LABEL VERSION 0.0.1
 
 WORKDIR /go/src/app
-COPY . /go/src/app
+COPY main.go .
 
+RUN go mod init
 RUN go get -d -v ./...
 
-RUN go build -o /go/bin/app
+# Detaails on when to utilize cgo: 
+#   https://pkg.go.dev/cmd/cgo  
+RUN CGO_ENABLED=0 go build -o /go/bin/app
 
-FROM gcr.io/distroless/base
+# Details on when to use Distroless Base vs Static:
+#   https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md
+#FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static
+
 COPY --from=build-env /go/bin/app /
 CMD ["/app"]

--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as build-env
+FROM golang:1.17 as build-env
 
 WORKDIR /go/src/app
 COPY *.go .

--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:latest as build-env
 
-LABEL NAME distroless-go-example
-LABEL VERSION 0.0.1
-
 WORKDIR /go/src/app
 COPY main.go .
 

--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -5,6 +5,8 @@ COPY *.go .
 
 RUN go mod init
 RUN go get -d -v ./...
+RUN go vet -v
+RUN go test -v
 
 # Details on when to utilize cgo: 
 #   https://pkg.go.dev/cmd/cgo  

--- a/examples/go/main_test.go
+++ b/examples/go/main_test.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test1(t *testing.T) {
+}


### PR DESCRIPTION
This pull request suggests the following changes:
* Update to golang:latest 
* Addition to initialize the module, needed for compilation
* Disable of cgo as the example does not require it
* Default to Distroless static vs base
* Documentation guidance on when it is necessary to utilize larger distroless/base base image