### PR TITLE
Increase timeout on bazel task for provenance generation

### DIFF
--- a/provenance/build-distroless-task.yaml
+++ b/provenance/build-distroless-task.yaml
@@ -40,6 +40,7 @@ spec:
         value: insecure-registry.default.svc.cluster.local:5000
       - name: COMMIT_SHA
         value: $(params.CHAINS-GIT_COMMIT)
+      timeout: 2h
       script: |
         #!/bin/sh
         set -ex


### PR DESCRIPTION
Most recent task from two days ago timed out at 1 hour, doubling. 