### PR TITLE
Update README.md - fix debug tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ $ docker run --entrypoint=sh -ti my_debug_image
 /app # ls
 BUILD       Dockerfile  hello.py
 ```
-> Note: If the image you are using already has a tag, for example `gcr.io/distroless/java17-debian11:nonroot`, use the tag `<existing tag>-debug` instead, for example `gcr.io/distroless/java17-debian11:nonroot-debug`.
+> Note: If the image you are using already has a tag, for example `gcr.io/distroless/java17-debian11:nonroot`, use the tag `debug-<existing tag>` instead, for example `gcr.io/distroless/java17-debian11:debug-nonroot`.
 
 > Note: [ldd](http://man7.org/linux/man-pages/man1/ldd.1.html) is not installed in the base image as it's a shell script, you can copy it in or download it.
 


### PR DESCRIPTION
Based on the following file, I believe that `debug` should be added as a prefix rather than as a suffix.
https://github.com/GoogleContainerTools/distroless/blob/b19f550dce74b65e09706e46fc82c0075434f563/BUILD#L29