### PR TITLE
Fix cosign build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -63,6 +63,13 @@ steps:
 - name: ubuntu
   entrypoint: ./cloudbuild_jq.sh
 
+# create a world writeable tmp dir in workspace for nonroot containers to write into
+- name: ubuntu
+  entrypoint: mkdir
+  args:
+  - -m777
+  - /workspace/tmp
+
 - name: gcr.io/projectsigstore/cosign:v1.3.1@sha256:3cd9b3a866579dc2e0cf2fdea547f4c9a27139276cc373165c26842bc594b8bd
   env:
   - PROJECT_ID=${PROJECT_ID}

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o xtrace
 
 # Temporary workaround for: https://github.com/GoogleContainerTools/distroless/issues/914
-export TUF_ROOT=/workspace/.sigstore/root
+export TUF_ROOT=/workspace/tmp/.sigstore/root
 mkdir -p $TUF_ROOT
 
 cosign version


### PR DESCRIPTION
create a world writeable tmp dir in workspace so cosign (nonroot)
container has a place to work

this is the second attempt at fixing #914 