### PR TITLE
Update TUF_ROOT

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -63,18 +63,14 @@ steps:
 - name: ubuntu
   entrypoint: ./cloudbuild_jq.sh
 
-# create a world writeable tmp dir in workspace for nonroot containers to write into
-- name: ubuntu
-  entrypoint: mkdir
-  args:
-  - -m777
-  - /workspace/tmp
-
 - name: gcr.io/projectsigstore/cosign:v1.3.1@sha256:3cd9b3a866579dc2e0cf2fdea547f4c9a27139276cc373165c26842bc594b8bd
   env:
   - PROJECT_ID=${PROJECT_ID}
   - COMMIT_SHA=${COMMIT_SHA}
   - REGISTRY=gcr.io
+  # Workaround for: https://github.com/GoogleContainerTools/distroless/issues/914
+  # /tmp has permissions 777
+  - TUF_ROOT=/tmp
   entrypoint: sh
   args:
   - -c
@@ -85,6 +81,9 @@ steps:
   - PROJECT_ID=${PROJECT_ID}
   - COMMIT_SHA=${COMMIT_SHA}
   - REGISTRY=gcr.io
+  # Workaround for: https://github.com/GoogleContainerTools/distroless/issues/914
+  # /tmp has permissions 777
+  - TUF_ROOT=/tmp
   - COSIGN_EXPERIMENTAL=true
   - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
   entrypoint: sh

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -3,10 +3,6 @@
 set -o errexit
 set -o xtrace
 
-# Temporary workaround for: https://github.com/GoogleContainerTools/distroless/issues/914
-export TUF_ROOT=/workspace/tmp/.sigstore/root
-mkdir -p $TUF_ROOT
-
 cosign version
 
 # Sign all images from 'images' file


### PR DESCRIPTION
Just use /tmp (777), creating our own temp in workspace was fine
when I didn't understand what was going on, but it's just cleaner
to do this. nonroot users can write into /tmp (this is user that
is running the cosign container, which is trying to write the
tuf root)