### PR TITLE
Include libcrypt1 in debian11 java images (fix netty-tcnative)

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -27,6 +27,7 @@ EXTRA_DEBS = {
     "debian10": [],
     "debian11": [
         "libbrotli1",
+        "libcrypt1",
     ],
 }
 


### PR DESCRIPTION
Fixes #942