### PR TITLE
Print HTTP status as decimal

### DIFF
--- a/debian_package_manager/internal/build/build.go
+++ b/debian_package_manager/internal/build/build.go
@@ -62,7 +62,7 @@ func resolvePackages(pi *deb.PackageIndex, packages map[string]bool) (map[string
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to fetch remote file: %q", pi.URL)
 	} else if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed (status: %q) to fetch remote file: %q", resp.StatusCode, pi.URL)
+		return nil, fmt.Errorf("failed (status: %d) to fetch remote file: %q", resp.StatusCode, pi.URL)
 	}
 	br := resp.Body
 	defer br.Close()


### PR DESCRIPTION
`%q` formatted 404 a Ɣ