### PR TITLE
Add multi-arch to node version tags

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -120,25 +120,40 @@ PYTHON3.update({
 })
 
 NODEJS = {
-    "{REGISTRY}/{PROJECT_ID}/nodejs:latest-amd64": "//nodejs:nodejs16_amd64_debian11",
-    "{REGISTRY}/{PROJECT_ID}/nodejs:latest-arm64": "//nodejs:nodejs16_arm64_debian11",
-    "{REGISTRY}/{PROJECT_ID}/nodejs:debug-amd64": "//nodejs:nodejs16_debug_amd64_debian11",
-    "{REGISTRY}/{PROJECT_ID}/nodejs:debug-arm64": "//nodejs:nodejs16_debug_arm64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs:12": "//nodejs:nodejs12_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs:14": "//nodejs:nodejs14_amd64_debian11",
-    "{REGISTRY}/{PROJECT_ID}/nodejs:16": "//nodejs:nodejs16_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs:12-debug": "//nodejs:nodejs12_debug_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs:14-debug": "//nodejs:nodejs14_debug_amd64_debian11",
-    "{REGISTRY}/{PROJECT_ID}/nodejs:16-debug": "//nodejs:nodejs16_debug_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:latest": "//nodejs:nodejs16_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:debug": "//nodejs:nodejs16_debug_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:12": "//nodejs:nodejs12_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:14": "//nodejs:nodejs14_amd64_debian11",
-    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:16": "//nodejs:nodejs16_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:12-debug": "//nodejs:nodejs12_debug_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:14-debug": "//nodejs:nodejs14_debug_amd64_debian11",
-    "{REGISTRY}/{PROJECT_ID}/nodejs-debian11:16-debug": "//nodejs:nodejs16_debug_amd64_debian11",
 }
+
+NODEJS.update({
+    "{REGISTRY}/{PROJECT_ID}/nodejs:" + tag_base + "-" + arch: "//nodejs:nodejs16" + suffix + "_" + arch + "_debian11"
+    for arch in BASE_ARCHITECTURES
+    for (tag_base, suffix) in [
+        ("latest", ""),
+        ("debug", "_debug"),
+        ("16", ""),
+        ("16-debug", "_debug"),
+    ]
+})
+
+NODEJS.update({
+    "{REGISTRY}/{PROJECT_ID}/nodejs-" + distro + ":" + tag_base + "-" + arch: "//nodejs:nodejs16" + suffix + "_" + arch + "_" + distro
+    for arch in BASE_ARCHITECTURES
+    for (tag_base, suffix) in [
+        ("latest", ""),
+        ("debug", "_debug"),
+        ("16", ""),
+        ("16-debug", "_debug"),
+    ]
+    for distro in LANGUAGE_DISTROS
+})
 
 JAVA_BASE = {
     "{REGISTRY}/{PROJECT_ID}/java-base:latest": "//java:java_base_root_amd64_debian11",

--- a/cloudbuild_cosign.sh
+++ b/cloudbuild_cosign.sh
@@ -33,8 +33,12 @@ cosign sign "$@" gcr.io/$PROJECT_ID/python3-debian11:latest
 cosign sign "$@" gcr.io/$PROJECT_ID/python3-debian11:debug-nonroot
 cosign sign "$@" gcr.io/$PROJECT_ID/python3-debian11:debug
 
-cosign sign "$@" gcr.io/$PROJECT_ID/nodejs:latest
-cosign sign "$@" gcr.io/$PROJECT_ID/nodejs:debug
+for distro_suffix in "" -debian11; do
+  cosign sign "$@" gcr.io/$PROJECT_ID/nodejs${distro_suffix}:latest
+  cosign sign "$@" gcr.io/$PROJECT_ID/nodejs${distro_suffix}:debug
+  cosign sign "$@" gcr.io/$PROJECT_ID/nodejs${distro_suffix}:16
+  cosign sign "$@" gcr.io/$PROJECT_ID/nodejs${distro_suffix}:16-debug
+done
 
 for java_version in -base 11 17; do
   cosign sign "$@" gcr.io/$PROJECT_ID/java${java_version}-debian11:latest

--- a/cloudbuild_docker.sh
+++ b/cloudbuild_docker.sh
@@ -56,12 +56,9 @@ for java_version in -base 11 17; do
   docker_manifest gcr.io/$PROJECT_ID/java${java_version}-debian11:debug-nonroot "amd64 arm64"
 done
 
-docker manifest create gcr.io/$PROJECT_ID/nodejs:latest \
-   gcr.io/$PROJECT_ID/nodejs:latest-amd64 \
-   gcr.io/$PROJECT_ID/nodejs:latest-arm64
-docker manifest push gcr.io/$PROJECT_ID/nodejs:latest
-
-docker manifest create gcr.io/$PROJECT_ID/nodejs:debug \
-   gcr.io/$PROJECT_ID/nodejs:debug-amd64 \
-   gcr.io/$PROJECT_ID/nodejs:debug-arm64
-docker manifest push gcr.io/$PROJECT_ID/nodejs:debug
+for distro_suffix in "" -debian11; do
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:latest "amd64 arm64"
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:debug "amd64 arm64"
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:16 "amd64 arm64"
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:16-debug "amd64 arm64"
+done


### PR DESCRIPTION
This converts the :16 tags to be multi-arch based on separate -amd64 and -arm64 tags. This ensures consumers can actually pin to a supported version and take advantage of multi-arch.

Most tags are now constructed systematically, which ensures they can't be missed while manually constructing the image list. This includes :latest and :debug tags.

debian10 is not getting multi-arch images like before.

Fixes #878.