### PR TITLE
Add correct busybox binary for arm64 architecture

### DIFF
--- a/busybox_archives.bzl
+++ b/busybox_archives.bzl
@@ -16,11 +16,15 @@ def repositories():
         urls = ["https://busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-armv7l"],
     )
 
+    # To update arm64 busybox binary (#657)
+    # Get the latest commit hash from dist-arm64v8 branch of docker-library repo.
+    # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/stable/musl/busybox.tar.xz
+    # Update the sha256 value. Since github api doesn't give sha256 value, it can be obtained using sha256sum command.
     http_file(
         name = "busybox_arm64",
         executable = True,
-        sha256 = "141adb1b625a6f44c4b114f76b4387b4ea4f7ab802b88eb40e0d2f6adcccb1c3",
-        urls = ["https://busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-armv8l"],
+        sha256 = "02033a50ef38a32a72b4b28183654116c42dae61ec9dccb349f9f63c6ae30f53",
+        urls = ["https://github.com/docker-library/busybox/raw/22bb23a2665eefb1520dc4c99d5ac9bdf87ae93b/stable/musl/busybox.tar.xz"],
     )
 
     http_file(

--- a/experimental/busybox/BUILD
+++ b/experimental/busybox/BUILD
@@ -4,8 +4,7 @@ load("//:checksums.bzl", "ARCHITECTURES")
 load(":commands.bzl", "BUSYBOX_COMMANDS")
 
 # This works for all architectures because it is just files.
-# Ppc64le needs special case as there is no direct working binary file available.
-# Like Ppc64le, Arm64 also uses busybox from https://github.com/docker-library/busybox to work around the arm64 compatibility problem of busybox-armv8l from busybox.net.
+# Ppc64le/Arm64 needs special case as there is no direct working binary file available.
 [genrule(
     name = "busybox_" + arch + "_tar",
     srcs = ["@busybox_" + arch + "//file"],

--- a/experimental/busybox/BUILD
+++ b/experimental/busybox/BUILD
@@ -5,12 +5,13 @@ load(":commands.bzl", "BUSYBOX_COMMANDS")
 
 # This works for all architectures because it is just files.
 # Ppc64le needs special case as there is no direct working binary file available.
+# Like Ppc64le, Arm64 also uses busybox from https://github.com/docker-library/busybox to work around the arm64 compatibility problem of busybox-armv8l from busybox.net. 
 [genrule(
     name = "busybox_" + arch + "_tar",
     srcs = ["@busybox_" + arch + "//file"],
     outs = ["busybox_" + arch + ".tar"],
     cmd = "mkdir busybox; cp $(<) busybox/busybox; cd busybox; \
-           if [[ $(<) == *ppc64le* ]]; then \
+           if [[ $(<) == *ppc64le* || $(<) == *arm64* ]]; then \
              tar -xf busybox ./bin && mv -f ./bin/busybox . && rm -rf ./bin; \
            fi; \
            for cmd in %s; do \

--- a/experimental/busybox/BUILD
+++ b/experimental/busybox/BUILD
@@ -5,7 +5,7 @@ load(":commands.bzl", "BUSYBOX_COMMANDS")
 
 # This works for all architectures because it is just files.
 # Ppc64le needs special case as there is no direct working binary file available.
-# Like Ppc64le, Arm64 also uses busybox from https://github.com/docker-library/busybox to work around the arm64 compatibility problem of busybox-armv8l from busybox.net. 
+# Like Ppc64le, Arm64 also uses busybox from https://github.com/docker-library/busybox to work around the arm64 compatibility problem of busybox-armv8l from busybox.net.
 [genrule(
     name = "busybox_" + arch + "_tar",
     srcs = ["@busybox_" + arch + "//file"],


### PR DESCRIPTION
This PR is reference to https://github.com/GoogleContainerTools/distroless/issues/657. The armv8l busybox binary currently present in the images doesn't work on arm64 CPUs without arm32 support hence using arm64v8 binary provided by [docker-library/busybox](https://github.com/docker-library/busybox/blob/dist-arm64v8/stable/musl/busybox.tar.xz).

This solution is inspired by the one for ppc64le arch: https://github.com/GoogleContainerTools/distroless/pull/723

I confirm the debug arm64 image built form this PR works well on Ubuntu 21 arm64 in Parallel Desktop and Docker on Apple Macbook Air 2020 (M1). This this  my build for try:
```
docker run -it mrmyh/base:debug-arm64
```