### PR TITLE
Update author to bot on deb updater

### DIFF
--- a/.github/workflows/update-deb-package-snapshots.yml
+++ b/.github/workflows/update-deb-package-snapshots.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         token: ${{ secrets.ACTIONS_TOKEN }}
         commit-message: "Bumping packages to latest stable versions"
+        author: "Distroless Bot <distroless-bot@google.com>"
         title: "Bumping packages to latest stable versions"
         body: "Bumping packages to latest stable versions"
         branch: "update-snapshots"


### PR DESCRIPTION
Appears to me that cron jobs are run in the context of a user that last changed the cron config (me). So commits are also made under that "actor". Just change the author here for the commits for consistency on the PRs.