### PR TITLE
Add node18 `18.0.0`

### DIFF
--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -30,6 +30,15 @@ def repositories():
         urls = ["https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-x64.tar.gz"],
     )
 
+	http_archive(
+        name = "nodejs18_amd64",
+        build_file = "//nodejs:BUILD.nodejs",
+        sha256 = "6260d3526dff25d43451ea8e90e0174975b4cd067e8535dc1d85a6d6b29f3043",
+        strip_prefix = "node-v18.0.0-linux-x64/",
+        type = "tar.gz",
+        urls = ["https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-x64.tar.gz"],
+    )
+
     http_archive(
         name = "nodejs12_arm64",
         build_file = "//nodejs:BUILD.nodejs",
@@ -55,4 +64,13 @@ def repositories():
         strip_prefix = "node-v16.14.2-linux-arm64/",
         type = "tar.gz",
         urls = ["https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-arm64.tar.gz"],
+    )
+
+	http_archive(
+        name = "nodejs18_arm64",
+        build_file = "//nodejs:BUILD.nodejs",
+        sha256 = "dc59b5191e2bffcb124e80e12a323b5f700c1fa57a83a1846531008aba1e154d",
+        strip_prefix = "node-v18.0.0-linux-arm64/",
+        type = "tar.gz",
+        urls = ["https://nodejs.org/dist/v18.0.0/node-v18.0.0-linux-arm64.tar.gz"],
     )

--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -30,7 +30,7 @@ def repositories():
         urls = ["https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-x64.tar.gz"],
     )
 
-	http_archive(
+    http_archive(
         name = "nodejs18_amd64",
         build_file = "//nodejs:BUILD.nodejs",
         sha256 = "6260d3526dff25d43451ea8e90e0174975b4cd067e8535dc1d85a6d6b29f3043",
@@ -66,7 +66,7 @@ def repositories():
         urls = ["https://nodejs.org/dist/v16.14.2/node-v16.14.2-linux-arm64.tar.gz"],
     )
 
-	http_archive(
+    http_archive(
         name = "nodejs18_arm64",
         build_file = "//nodejs:BUILD.nodejs",
         sha256 = "dc59b5191e2bffcb124e80e12a323b5f700c1fa57a83a1846531008aba1e154d",

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -5,7 +5,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("//base:distro.bzl", DISTROS = "LANGUAGE_DISTROS")
 load("//:checksums.bzl", ARCHITECTURES = "BASE_ARCHITECTURES")
 
-NODEJS_MAJOR_VERISONS = ("12", "14", "16")
+NODEJS_MAJOR_VERISONS = ("12", "14", "16", "18")
 
 [
     container_image(

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -9,6 +9,7 @@ Specifically, these images contain everything in the [base image](../base/README
 - Node.js v12 (`gcr.io/distroless/nodejs:12`) and its dependencies.
 - Node.js v14 (`gcr.io/distroless/nodejs:14`) and its dependencies.
 - Node.js v16 (`gcr.io/distroless/nodejs:16`) and its dependencies.
+- Node.js v18 (`gcr.io/distroless/nodejs:18`) and its dependencies.
 
 **Note:** the `latest` tag maps to Node.js v16 to follow the official node docker images. However we recommend that users of these images should explicitly set the LTS version tag they wish to use.
 

--- a/nodejs/testdata/nodejs18.yaml
+++ b/nodejs/testdata/nodejs18.yaml
@@ -1,0 +1,6 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: nodejs
+    command: "/nodejs/bin/node"
+    args: ["--version"]
+    expectedOutput: ['v18.0.0']


### PR DESCRIPTION
Unsure wether to add it now, or when Active LTS starts in October.