### PR TITLE
Update example for Go 1.18 and switch to using `go mod download`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,16 @@ Follow these steps to get started:
 
   ```dockerfile
   # Start by building the application.
-  FROM golang:1.17-bullseye as build
+  FROM golang:1.18 as build
 
   WORKDIR /go/src/app
-  ADD . /go/src/app
+  COPY . .
 
-  RUN go get -d -v ./...
-
-  RUN go build -o /go/bin/app
+  RUN go mod download
+  RUN CGO_ENABLED=0 go build -o /go/bin/app
 
   # Now copy it into our base image.
-  FROM gcr.io/distroless/base-debian11
+  FROM gcr.io/distroless/static-debian11
   COPY --from=build /go/bin/app /
   CMD ["/app"]
   ```

--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -1,16 +1,15 @@
-FROM golang:1.17 as build-env
+FROM golang:1.18 as build
 
 WORKDIR /go/src/app
-COPY *.go ./
+COPY . .
 
-RUN go mod init
-RUN go get -d -v ./...
+RUN go mod download
 RUN go vet -v
 RUN go test -v
 
 RUN CGO_ENABLED=0 go build -o /go/bin/app
 
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/static-debian11
 
-COPY --from=build-env /go/bin/app /
+COPY --from=build /go/bin/app /
 CMD ["/app"]

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/distroless/examples/go
+
+go 1.18


### PR DESCRIPTION
I think `go mod download` is better suited for an example rather than `go get -d -v` as everyone should be using modules at this point.

Also consolidated the example and the one shown in the README as well as bumping to Go 1.18