### PR TITLE
Fix relative link to cloudbuild.yaml in RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,4 +2,4 @@
 
 Images in this repository are built and released in the `gcr.io/distroless` repository on the [Google Container Registry](https://cloud.google.com/container-registry/).
 
-Images are automatically built and pushed every commit, according to the policy defined in [cloudbuild.yaml].
+Images are automatically built and pushed every commit, according to the policy defined in [cloudbuild.yaml](/cloudbuild.yaml).


### PR DESCRIPTION
This PR fixes a relative link to the top-level `cloudbuild.yaml` in  in `RELEASES.md`.