### PR TITLE
Ignore s390x and ppc64le security indexes debian10

### DIFF
--- a/.github/workflows/ci-cache.yaml
+++ b/.github/workflows/ci-cache.yaml
@@ -1,11 +1,7 @@
 name: cache CI
 
 on:
-  workflow_dispatch: # Allow manual runs.
-  pull_request:
-    branches: [ 'main' ]
-  push:
-    branches: [ 'main' ]
+  workflow_dispatch: # Allow manual runs
 
 jobs:
   build-and-test:

--- a/debian_package_manager/internal/deb/packageindex.go
+++ b/debian_package_manager/internal/deb/packageindex.go
@@ -20,6 +20,13 @@ import (
 )
 
 func PackageIndexGroup(snapshots *config.Snapshots, arch config.Arch, distro config.Distro) []*PackageIndex {
+	// special casing for missing security distros
+	if (arch == config.PPC64LE || arch == config.S390X) && distro == config.DEBIAN10 {
+		return []*PackageIndex{
+			Main(snapshots.Debian, arch, distro),
+			Updates(snapshots.Debian, arch, distro),
+		}
+	}
 	return []*PackageIndex{
 		Main(snapshots.Debian, arch, distro),
 		Updates(snapshots.Debian, arch, distro),
@@ -31,6 +38,7 @@ type PackageIndex struct {
 	URL      string
 	PoolRoot string
 	Snapshot string
+	Channel  string
 	Distro   config.Distro
 	Arch     config.Arch
 }

--- a/debian_package_manager/internal/deb/snapshot.go
+++ b/debian_package_manager/internal/deb/snapshot.go
@@ -82,6 +82,7 @@ func Main(snapshot string, arch config.Arch, distro config.Distro) *PackageIndex
 		Snapshot: snapshot,
 		Distro:   distro,
 		Arch:     arch,
+		Channel:  "main",
 	}
 }
 
@@ -92,6 +93,7 @@ func Updates(snapshot string, arch config.Arch, distro config.Distro) *PackageIn
 		Snapshot: snapshot,
 		Distro:   distro,
 		Arch:     arch,
+		Channel:  "updates",
 	}
 }
 
@@ -106,5 +108,6 @@ func Security(snapshot string, arch config.Arch, distro config.Distro) *PackageI
 		Snapshot: snapshot,
 		Distro:   distro,
 		Arch:     arch,
+		Channel:  "security",
 	}
 }


### PR DESCRIPTION
- They don't seem to be published anymore
- We will probably see some regressions in versions
  for those architectures unfortunately
- Better to not keep the rest of distroless hostage
  on this

Signed-off-by: Appu Goundan <appu@google.com>

fixes #1100 