### PR TITLE
Added s390x and ppc64le support for NodeJS

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,6 +9,11 @@ JAVA_ARCHITECTURES = BASE_ARCHITECTURES + [
     "ppc64le",
 ]
 
+NODE_ARCHITECTURES = BASE_ARCHITECTURES + [
+    "s390x",
+    "ppc64le",
+]
+
 LABEL_USERS = [
     ("latest", "root"),
     ("nonroot", "nonroot"),
@@ -133,7 +138,7 @@ NODEJS = {
 
 NODEJS.update({
     "{REGISTRY}/{PROJECT_ID}/nodejs:" + tag_base + "-" + arch: "//nodejs:nodejs16" + suffix + "_" + arch + "_debian11"
-    for arch in BASE_ARCHITECTURES
+    for arch in NODE_ARCHITECTURES
     for (tag_base, suffix) in [
         ("16", ""),
         ("16-debug", "_debug"),
@@ -142,7 +147,7 @@ NODEJS.update({
 
 NODEJS.update({
     "{REGISTRY}/{PROJECT_ID}/nodejs-" + distro + ":" + tag_base + "-" + arch: "//nodejs:nodejs16" + suffix + "_" + arch + "_" + distro
-    for arch in BASE_ARCHITECTURES
+    for arch in NODE_ARCHITECTURES
     for (tag_base, suffix) in [
         ("16", ""),
         ("16-debug", "_debug"),
@@ -152,7 +157,7 @@ NODEJS.update({
 
 NODEJS.update({
     "{REGISTRY}/{PROJECT_ID}/nodejs:" + tag_base + "-" + arch: "//nodejs:nodejs18" + suffix + "_" + arch + "_debian11"
-    for arch in BASE_ARCHITECTURES
+    for arch in NODE_ARCHITECTURES
     for (tag_base, suffix) in [
         ("latest", ""),
         ("debug", "_debug"),
@@ -163,7 +168,7 @@ NODEJS.update({
 
 NODEJS.update({
     "{REGISTRY}/{PROJECT_ID}/nodejs-" + distro + ":" + tag_base + "-" + arch: "//nodejs:nodejs18" + suffix + "_" + arch + "_" + distro
-    for arch in BASE_ARCHITECTURES
+    for arch in NODE_ARCHITECTURES
     for (tag_base, suffix) in [
         ("latest", ""),
         ("debug", "_debug"),

--- a/cloudbuild_docker.sh
+++ b/cloudbuild_docker.sh
@@ -59,10 +59,10 @@ for java_version in -base 11 17; do
 done
 
 for distro_suffix in "" -debian11; do
-  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:latest "amd64 arm64"
-  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:debug "amd64 arm64"
-  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:18 "amd64 arm64"
-  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:18-debug "amd64 arm64"
-  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:16 "amd64 arm64"
-  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:16-debug "amd64 arm64"
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:latest "amd64 arm64 s390x ppc64le"
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:debug "amd64 arm64 s390x ppc64le"
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:18 "amd64 arm64 s390x ppc64le"
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:18-debug "amd64 arm64 s390x ppc64le"
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:16 "amd64 arm64 s390x ppc64le"
+  docker_manifest gcr.io/$PROJECT_ID/nodejs${distro_suffix}:16-debug "amd64 arm64 s390x ppc64le"
 done

--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -56,3 +56,57 @@ def repositories():
         type = "tar.gz",
         urls = ["https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-arm64.tar.gz"],
     )
+
+    http_archive(
+        name = "nodejs14_ppc64le",
+        build_file = "//nodejs:BUILD.nodejs",
+        sha256 = "b61f6ab4ec04e8b607b692199203ee3f88a6344ffa027dc90aa023b47f3edd95",
+        strip_prefix = "node-v14.20.0-linux-ppc64le/",
+        type = "tar.gz",
+        urls = ["https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-ppc64le.tar.gz"],
+    )
+
+    http_archive(
+        name = "nodejs16_ppc64le",
+        build_file = "//nodejs:BUILD.nodejs",
+        sha256 = "3f1c57af5994e4f524d33e0173e5b60a76ad2347bc4b838719bc06cc0a1ef1c3",
+        strip_prefix = "node-v16.16.0-linux-ppc64le/",
+        type = "tar.gz",
+        urls = ["https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-ppc64le.tar.gz"],
+    )
+
+    http_archive(
+        name = "nodejs18_ppc64le",
+        build_file = "//nodejs:BUILD.nodejs",
+        sha256 = "a5d2a43630f0a381bace91c31a7e7752b64341c3d8b2eaf5515f814fad07a231",
+        strip_prefix = "node-v18.7.0-linux-ppc64le/",
+        type = "tar.gz",
+        urls = ["https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-ppc64le.tar.gz"],
+    )
+
+    http_archive(
+        name = "nodejs14_s390x",
+        build_file = "//nodejs:BUILD.nodejs",
+        sha256 = "5d1b24364d7de9ad7cc96250caa897949760ffd41398c1865577183a0b9e1cca",
+        strip_prefix = "node-v14.20.0-linux-s390x/",
+        type = "tar.gz",
+        urls = ["https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-s390x.tar.gz"],
+    )
+
+    http_archive(
+        name = "nodejs16_s390x",
+        build_file = "//nodejs:BUILD.nodejs",
+        sha256 = "b71b5dd31f398c5467cc3b93a79d5757e7ad286e5ad2bd79d5fda6b775b481c7",
+        strip_prefix = "node-v16.16.0-linux-s390x/",
+        type = "tar.gz",
+        urls = ["https://nodejs.org/dist/v16.16.0/node-v16.16.0-linux-s390x.tar.gz"],
+    )
+
+    http_archive(
+        name = "nodejs18_s390x",
+        build_file = "//nodejs:BUILD.nodejs",
+        sha256 = "3d5330337892ff21a5fb7058a68aee3274ab36637b212380cbb78c45cd15244b",
+        strip_prefix = "node-v18.7.0-linux-s390x/",
+        type = "tar.gz",
+        urls = ["https://nodejs.org/dist/v18.7.0/node-v18.7.0-linux-s390x.tar.gz"],
+    )

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -5,7 +5,12 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("//base:distro.bzl", DISTROS = "LANGUAGE_DISTROS")
 load("//:checksums.bzl", ARCHITECTURES = "BASE_ARCHITECTURES")
 
-NODEJS_MAJOR_VERISONS = ("14", "16", "18")
+NODEJS_MAJOR_VERSIONS = ("14", "16", "18")
+
+NODE_ARCHITECTURES = ARCHITECTURES + [
+    "s390x",
+    "ppc64le",
+]
 
 [
     container_image(
@@ -19,8 +24,8 @@ NODEJS_MAJOR_VERISONS = ("14", "16", "18")
         "",
         "_debug",
     ]
-    for major_version in NODEJS_MAJOR_VERISONS
-    for arch in ARCHITECTURES
+    for major_version in NODEJS_MAJOR_VERSIONS
+    for arch in NODE_ARCHITECTURES
     for distro in DISTROS
 ]
 
@@ -41,8 +46,8 @@ NODEJS_MAJOR_VERISONS = ("14", "16", "18")
         "",
         "_debug",
     ]
-    for major_version in NODEJS_MAJOR_VERISONS
-    for arch in ARCHITECTURES
+    for major_version in NODEJS_MAJOR_VERSIONS
+    for arch in NODE_ARCHITECTURES
     for distro in DISTROS
 ]
 
@@ -60,8 +65,8 @@ exports_files([
         "",
         "_debug",
     ]
-    for major_version in NODEJS_MAJOR_VERISONS
-    for arch in ARCHITECTURES
+    for major_version in NODEJS_MAJOR_VERSIONS
+    for arch in NODE_ARCHITECTURES
     for distro in DISTROS
 ]
 
@@ -79,7 +84,7 @@ exports_files([
         "",
         "_debug",
     ]
-    for major_version in NODEJS_MAJOR_VERISONS
-    for arch in ARCHITECTURES
+    for major_version in NODEJS_MAJOR_VERSIONS
+    for arch in NODE_ARCHITECTURES
     for distro in DISTROS
 ]


### PR DESCRIPTION
Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>

This PR adds support for platforms ppc64le and s390x to the existing NodeJS images. Similar platform enablements for Java have been done a while ago in PRs https://github.com/GoogleContainerTools/distroless/pull/1068 and https://github.com/GoogleContainerTools/distroless/pull/1070