### PR TITLE
Add base_nossl image

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -70,6 +70,34 @@ BASE.update({
     for distro in DISTROS
 })
 
+BASE_NOSSL = {
+    "{REGISTRY}/{PROJECT_ID}/preview/base-nossl:{COMMIT_SHA}": "//base:base_nossl_root_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/preview/base-nossl-debian11:{COMMIT_SHA}": "//base:base_nossl_root_amd64_debian11",
+}
+
+BASE_NOSSL.update({
+    "{REGISTRY}/{PROJECT_ID}/preview/base-nossl:" + tag_base + "-" + arch: "//base:" + label + "_" + user + "_" + arch + "_debian11"
+    for arch in ARCHITECTURES
+    for (tag_base, label, user) in [
+        ("latest", "base_nossl", "root"),
+        ("nonroot", "base_nossl", "nonroot"),
+        ("debug", "base_nossl_debug", "root"),
+        ("debug-nonroot", "base_nossl_debug", "nonroot"),
+    ]
+})
+
+BASE_NOSSL.update({
+    "{REGISTRY}/{PROJECT_ID}/preview/base-nossl-" + distro + ":" + tag_base + "-" + arch: "//base:" + label + "_" + user + "_" + arch + "_" + distro
+    for arch in ARCHITECTURES
+    for (tag_base, label, user) in [
+        ("latest", "base_nossl", "root"),
+        ("nonroot", "base_nossl", "nonroot"),
+        ("debug", "base_nossl_debug", "root"),
+        ("debug-nonroot", "base_nossl_debug", "nonroot"),
+    ]
+    for distro in DISTROS
+})
+
 CC = {
     "{REGISTRY}/{PROJECT_ID}/cc:{COMMIT_SHA}": "//cc:cc_root_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/cc-debian11:{COMMIT_SHA}": "//cc:cc_root_amd64_debian11",
@@ -270,6 +298,8 @@ ALL = {}
 ALL.update(STATIC)
 
 ALL.update(BASE)
+
+ALL.update(BASE_NOSSL)
 
 ALL.update(CC)
 

--- a/base/base.bzl
+++ b/base/base.bzl
@@ -52,6 +52,15 @@ def distro_components(distro):
             )
 
             container_image(
+                name = "base_nossl_" + user + "_" + arch + "_" + distro,
+                architecture = arch,
+                base = ":static_" + user + "_" + arch + "_" + distro,
+                debs = [
+                    deb_file(arch, distro, "libc6"),
+                ],
+            )
+
+            container_image(
                 name = "base_" + user + "_" + arch + "_" + distro,
                 architecture = arch,
                 base = ":static_" + user + "_" + arch + "_" + distro,
@@ -67,6 +76,17 @@ def distro_components(distro):
                 name = "debug_" + user + "_" + arch + "_" + distro,
                 architecture = arch,
                 base = ":base_" + user + "_" + arch + "_" + distro,
+                directory = "/",
+                entrypoint = ["/busybox/sh"],
+                env = {"PATH": "$$PATH:/busybox"},
+                tars = ["//experimental/busybox:busybox_" + arch + ".tar"],
+            )
+
+            # A base_nossl debug image with busybox available.
+            container_image(
+                name = "base_nossl_debug_" + user + "_" + arch + "_" + distro,
+                architecture = arch,
+                base = ":base_nossl_" + user + "_" + arch + "_" + distro,
                 directory = "/",
                 entrypoint = ["/busybox/sh"],
                 env = {"PATH": "$$PATH:/busybox"},
@@ -133,6 +153,13 @@ def distro_components(distro):
             tags = ["manual", arch],
         )
 
+        container_test(
+            name = "base_nossl_" + arch + "_" + distro + "_test",
+            configs = ["testdata/base.yaml"],
+            image = ":base_nossl_root_" + arch + "_" + distro,
+            tags = ["manual", arch],
+        )
+
         ##########################################################################################
         # Check for busybox
         ##########################################################################################
@@ -140,6 +167,13 @@ def distro_components(distro):
             name = "debug_" + arch + "_" + distro + "_test",
             configs = ["testdata/debug.yaml"],
             image = ":debug_root_" + arch + "_" + distro,
+            tags = ["manual", arch],
+        )
+
+        container_test(
+            name = "base_nossl_debug_" + arch + "_" + distro + "_test",
+            configs = ["testdata/debug.yaml"],
+            image = ":base_nossl_debug_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
 
@@ -157,6 +191,13 @@ def distro_components(distro):
             name = "base_release_" + arch + "_" + distro + "_test",
             configs = ["testdata/" + distro + ".yaml"],
             image = ":base_root_" + arch + "_" + distro,
+            tags = ["manual", arch],
+        )
+
+        container_test(
+            name = "base_nossl_release_" + arch + "_" + distro + "_test",
+            configs = ["testdata/" + distro + ".yaml"],
+            image = ":base_nossl_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
 


### PR DESCRIPTION
will be published to `gcr.io/distroless/preview/base-nossl*` and moved to `gcr.io/distroless/base-nossl*` when tested

Signed-off-by: Appu Goundan <appu@google.com>

part of #1098