### PR TITLE
Update examples.yaml

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -11,4 +11,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - run: ldd --version
       - run: ./examples/test.sh

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   examples:
     name: Build and run examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04  # contains libc that is compatible with debian11 (22.04/latest doesn't)
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes broken examples tests, ubuntu-latest tag appears to have been updated to 22.04 (even though docs currently say otherwise). Explicitly use 20.04 here which has a compatible libc mostly for the c examples which compile against it.