### PR TITLE
update pkg_tar

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 load(":base.bzl", "NONROOT", "distro_components")
 load(":distro.bzl", "DISTROS")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_docker//contrib:group.bzl", "group_entry", "group_file")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_tar")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")

--- a/examples/nonroot/BUILD
+++ b/examples/nonroot/BUILD
@@ -1,7 +1,7 @@
 # Public notice: this file is for internal documentation, testing, and
 # reference only. Note that repo maintainers can freely change any part of the
 # repository code at any time.
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")

--- a/java/BUILD.jetty
+++ b/java/BUILD.jetty
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "tar",

--- a/nodejs/BUILD.nodejs
+++ b/nodejs/BUILD.nodejs
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "tar",


### PR DESCRIPTION
move from deprecated `@bazel_tools//tools/build_defs/pkg:pkg.bzl` to `@rules_pkg//:pkg.bzl`