### PR TITLE
Revert "Fix: Use `SOURCE_DATE_EPOCH` for the distroless images."

### DIFF
--- a/base/base.bzl
+++ b/base/base.bzl
@@ -21,7 +21,6 @@ def distro_components(distro):
         for (user, uid, workdir) in [("root", 0, "/"), ("nonroot", NONROOT, "/home/nonroot")]:
             container_image(
                 name = "static_" + user + "_" + arch + "_" + distro,
-                stamp = True,
                 debs = [
                     deb_file(arch, distro, "base-files"),
                     deb_file(arch, distro, "netbase"),
@@ -54,7 +53,6 @@ def distro_components(distro):
 
             container_image(
                 name = "base_nossl_" + user + "_" + arch + "_" + distro,
-                stamp = True,
                 architecture = arch,
                 base = ":static_" + user + "_" + arch + "_" + distro,
                 debs = [
@@ -64,7 +62,6 @@ def distro_components(distro):
 
             container_image(
                 name = "base_" + user + "_" + arch + "_" + distro,
-                stamp = True,
                 architecture = arch,
                 base = ":static_" + user + "_" + arch + "_" + distro,
                 debs = [
@@ -77,7 +74,6 @@ def distro_components(distro):
             # A debug image with busybox available.
             container_image(
                 name = "debug_" + user + "_" + arch + "_" + distro,
-                stamp = True,
                 architecture = arch,
                 base = ":base_" + user + "_" + arch + "_" + distro,
                 directory = "/",
@@ -89,7 +85,6 @@ def distro_components(distro):
             # A base_nossl debug image with busybox available.
             container_image(
                 name = "base_nossl_debug_" + user + "_" + arch + "_" + distro,
-                stamp = True,
                 architecture = arch,
                 base = ":base_nossl_" + user + "_" + arch + "_" + distro,
                 directory = "/",
@@ -101,7 +96,6 @@ def distro_components(distro):
             # A static debug image with busybox available.
             container_image(
                 name = "static_debug_" + user + "_" + arch + "_" + distro,
-                stamp = True,
                 architecture = arch,
                 base = ":static_" + user + "_" + arch + "_" + distro,
                 directory = "/",

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -22,7 +22,6 @@ DISTRO_DEBS = {
             deb_file(arch, distro, "libgomp1"),
             deb_file(arch, distro, "libstdcpp6"),
         ] + [deb_file(arch, distro, deb) for deb in DISTRO_DEBS[distro]],
-        stamp = True,
     )
     for mode in [
         "",

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,14 +28,6 @@ steps:
     set -o errexit
     set -o xtrace
 
-    if [ ! -z "${_COMMIT_DATE}" ] ; then
-      export SOURCE_DATE_EPOCH=$(date --date="${_COMMIT_DATE}" +"%s")
-    else
-      # When a _COMMIT_DATE is not specified, set the SOURCE_DATE_EPOCH
-      # to zero to preserve the reproducibility of the build.
-      export SOURCE_DATE_EPOCH=0
-    fi
-
     # package manager needs wget
     apt-get install wget
 
@@ -45,8 +37,8 @@ steps:
     # fetch all dependencies with retries and backoff
     for i in $(seq 5); do bazel fetch --loading_phase_threads=1 //... && break || sleep 20; done
 
-    bazel run --stamp //:publish
-    bazel build --stamp all.tar
+    bazel run //:publish
+    bazel build all.tar
 
 - name: docker
   env:
@@ -85,12 +77,3 @@ steps:
   args:
   - -c
   - ./cloudbuild_cosign.sh
-
-substitutions:
-  # This is populated by build triggers according to:
-  # https://cloud.google.com/build/docs/configuring-builds/use-bash-and-bindings-in-substitutions#creating_substitutions_using_payload_bindings
-  # in particular we set this up to have the value:
-  #    $(commit.commit.committer.date)
-  # You may specify this to gcloud builds submit with the following value:
-  #    $(git log -1 --date=iso-strict --pretty=%cd)
-  _COMMIT_DATE: "" # default value

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -52,7 +52,6 @@ DISTRO_VERSION = {
         ],
         # Use UTF-8 encoding for file system: match modern Linux
         env = {"LANG": "C.UTF-8"},
-        stamp = True,
         symlinks = {
             "/usr/bin/python": "/usr/bin/python" + DISTRO_VERSION[distro],
             "/usr/bin/python3": "/usr/bin/python" + DISTRO_VERSION[distro],
@@ -75,7 +74,6 @@ DISTRO_VERSION = {
         name = ("python3" if (not mode) else mode[1:]) + "_nonroot_" + arch + "_" + distro,
         architecture = arch,
         base = ("python3" if (not mode) else mode[1:]) + "_root_" + arch + "_" + distro,
-        stamp = True,
         user = "%d" % NONROOT,
         workdir = "/home/nonroot",
     )

--- a/java/BUILD
+++ b/java/BUILD
@@ -58,7 +58,6 @@ JAVA_VERSIONS = [
             deb_file(arch, distro, "libcrypt1"),
         ],
         env = {"LANG": "C.UTF-8"},
-        stamp = True,
         tars = [
             ":cacerts_java_" + arch + "_" + distro,
             "//locale:locale_" + arch + "_" + distro,
@@ -90,7 +89,6 @@ JAVA_VERSIONS = [
             "-jar",
         ],
         env = {"JAVA_VERSION": jre_ver(DEBIAN_VERSIONS[arch][distro]["openjdk-" + java_version + "-jre-headless"])},
-        stamp = True,
         symlinks = {"/usr/bin/java": "/usr/lib/jvm/java-" + java_version + "-openjdk-" + arch + "/bin/java"},
     )
     for java_version in JAVA_VERSIONS
@@ -123,7 +121,6 @@ JAVA_VERSIONS = [
             "-jar",
         ],
         env = {"JAVA_VERSION": jre_ver(DEBIAN_VERSIONS[arch][distro]["openjdk-" + java_version + "-jre-headless"])},
-        stamp = True,
         symlinks = {"/usr/bin/java": "/usr/lib/jvm/java-" + java_version + "-openjdk-" + arch + "/bin/java"},
     )
     for user in USERS

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -13,7 +13,6 @@ NODEJS_MAJOR_VERISONS = ("14", "16", "18")
         architecture = arch,
         base = ("//cc:cc" if (not ("debug" in mode)) else "//cc:debug") + "_" + user + "_" + arch + "_" + distro,
         entrypoint = ["/nodejs/bin/node"],
-        stamp = True,
         tars = ["@nodejs" + major_version + "_" + arch + "//:tar"],
     )
     for mode in [


### PR DESCRIPTION
Reverts GoogleContainerTools/distroless#1203

Stamping was causing some unnecessary updates in repos: #1239 . We'll revert this for now and figure out a better solution.