### PR TITLE
Add precision-shell as a user of Distroless

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ BUILD       Dockerfile  hello.py
 - [Kubernetes](https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/1729-rebase-images-to-distroless/README.md), since v1.15
 - [Knative](https://knative.dev)
 - [Tekton](https://tekton.dev)
+- [precision-shell](https://github.com/groboclown/precision-shell)
 
 If your project uses Distroless, send a PR to add your project here!
 


### PR DESCRIPTION
Precision-Shell is a tool to provide 'just enough shell' to add a touch of functionality on top of a minimal docker image.  The tool uses Distroless in the [recipes](https://github.com/groboclown/precision-shell/tree/main/recipes) for using the tool.