### PR TITLE
Remove EOL nodejs14

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -196,7 +196,6 @@ PYTHON3 |= {
 
 ## NODEJS
 NODEJS_VERSIONS = [
-    "14",
     "16",
     "18",
     "20",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The following images are currently published and updated by the distroless proje
 | gcr.io/distroless/java-base-debian11  | latest, nonroot, debug, debug-nonroot  |
 | gcr.io/distroless/java11-debian11     | latest, nonroot, debug, debug-nonroot  |
 | gcr.io/distroless/java17-debian11     | latest, nonroot, debug, debug-nonroot  |
-| gcr.io/distroless/nodejs14-debian11   | latest, nonroot, debug, debug-nonroot  |
 | gcr.io/distroless/nodejs16-debian11   | latest, nonroot, debug, debug-nonroot  |
 | gcr.io/distroless/nodejs18-debian11   | latest, nonroot, debug, debug-nonroot  |
 | gcr.io/distroless/nodejs20-debian11   | latest, nonroot, debug, debug-nonroot  |
@@ -102,7 +101,6 @@ Follow these steps to get started:
     * [gcr.io/distroless/java11-debian11](java/README.md)
     * [gcr.io/distroless/java17-debian11](java/README.md)
     * [gcr.io/distroless/cc-debian11](cc/README.md)
-    * [gcr.io/distroless/nodejs14-debian11](nodejs/README.md)
     * [gcr.io/distroless/nodejs16-debian11](nodejs/README.md)
     * [gcr.io/distroless/nodejs18-debian11](nodejs/README.md)
     * [gcr.io/distroless/nodejs20-debian11](nodejs/README.md)

--- a/SUPPORT_POLICY.md
+++ b/SUPPORT_POLICY.md
@@ -21,7 +21,7 @@ The current estimation of end of life for images with the pattern:
 Java will only support current LTS version distributed by debian [see here](https://wiki.debian.org/Java).
 
 ### Node
-Node version support is for even numbered releases (14, 16, 18, 20, etc) that are current, active or in LTS maintenance. For more information, [see here](https://nodejs.org/en/about/releases/).
+Node version support is for even numbered releases (16, 18, 20, etc) that are current, active or in LTS maintenance. For more information, [see here](https://nodejs.org/en/about/releases/).
 
 ### Python
 Python support is experimental, and this project does not make any guarantees about the version of python in images.

--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -3,15 +3,6 @@ load("//private/remote:node_archive.bzl", "node_archive")
 def repositories():
     # Node (https://nodejs.org/en/about/releases/)
     # Follow Node's maintainence schedule and support all LTS versions that are not end of life
-    node_archive(
-        name = "nodejs14_amd64",
-        sha256 = "bef2685d9469058c1229cc7789e171861044fe3f70316ec744e9bf3609cd45ed",
-        strip_prefix = "node-v14.21.3-linux-x64/",
-        urls = ["https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-x64.tar.gz"],
-        version = "14.21.3",
-        architecture = "amd64",
-        control = "//nodejs:control",
-    )
 
     node_archive(
         name = "nodejs16_amd64",
@@ -40,16 +31,6 @@ def repositories():
         urls = ["https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.gz"],
         version = "20.0.0",
         architecture = "amd64",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs14_arm64",
-        sha256 = "044b7ec3fea04cd3815d26901ee37203dcc942688b72ee6eac96f6a1ca3cc63f",
-        strip_prefix = "node-v14.21.3-linux-arm64/",
-        urls = ["https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-arm64.tar.gz"],
-        version = "14.21.3",
-        architecture = "arm64",
         control = "//nodejs:control",
     )
 

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -5,7 +5,7 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
 
-NODEJS_MAJOR_VERISONS = ("14", "16", "18", "20")
+NODEJS_MAJOR_VERISONS = ("16", "18", "20")
 
 MODE = [
     "",

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -6,7 +6,6 @@ These images contain a minimal Linux, Node.js-based runtime. The supported versi
 
 Specifically, these images contain everything in the [base image](../base/README.md), plus one of:
 
-- Node.js v14 (`gcr.io/distroless/nodejs14-debian11`) and its dependencies.
 - Node.js v16 (`gcr.io/distroless/nodejs16-debian11`) and its dependencies.
 - Node.js v18 (`gcr.io/distroless/nodejs18-debian11`) and its dependencies.
 - Node.js v20 (`gcr.io/distroless/nodejs20-debian11`) and its dependencies.

--- a/nodejs/testdata/nodejs14.yaml
+++ b/nodejs/testdata/nodejs14.yaml
@@ -1,6 +1,0 @@
-schemaVersion: "2.0.0"
-commandTests:
-  - name: nodejs
-    command: "/nodejs/bin/node"
-    args: ["--version"]
-    expectedOutput: ['v14.21.3']


### PR DESCRIPTION
This **_must_** be merged after the actual EOL date (30 Apr 2023)

Indirectly this PR closes https://github.com/GoogleContainerTools/distroless/issues/1002