### PR TITLE
Updating busybox to 1.35.0

### DIFF
--- a/base/testdata/debug.yaml
+++ b/base/testdata/debug.yaml
@@ -7,4 +7,4 @@ fileExistenceTests:
 commandTests:
   - name: busybox
     command: ["/busybox/busybox"]
-    expectedOutput: ['BusyBox v1\.34\.1']
+    expectedOutput: ['BusyBox v1\.35\.0']

--- a/busybox_archives.bzl
+++ b/busybox_archives.bzl
@@ -3,14 +3,15 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 # For the debug image
 def repositories():
     # To update amd64 busybox binary (#1014)
-    # Get the latest commit hash from dist-amd64 branch of docker-library repo.
-    # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/stable/musl/busybox.tar.xz
+    # Get the latest commit hash from dist-amd64 branch of docker-library repo. You can also view it
+    # at https://github.com/docker-library/official-images/blob/master/library/busybox
+    # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/latest-1/musl/busybox.tar.xz
     # Update the sha256 value. Since github api doesn't give sha256 value, it can be obtained using sha256sum command.
     http_file(
         name = "busybox_amd64",
         executable = True,
-        sha256 = "169548e8934284b7292bc359ba542c0cfad0b14069881294a6e6939555afbfc0",
-        urls = ["https://github.com/docker-library/busybox/raw/8822d69939aa6c41b50c66d0a4c5a5f8729f2178/stable/musl/busybox.tar.xz"],
+        sha256 = "2af6ea3f9a4a3a19bf4924006f0e4797ea8fe8a370b99717dc0649a5a8af820a",
+        urls = ["https://github.com/docker-library/busybox/raw/c4c1b1f404daebc67a32c5949d5d5b3af3b14302/latest-1/musl/busybox.tar.xz"],
     )
 
     http_file(
@@ -21,14 +22,15 @@ def repositories():
     )
 
     # To update arm64 busybox binary (#657)
-    # Get the latest commit hash from dist-arm64v8 branch of docker-library repo.
-    # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/stable/musl/busybox.tar.xz
+    # Get the latest commit hash from dist-arm64v8 branch of docker-library repo. You can also view it
+    # at https://github.com/docker-library/official-images/blob/master/library/busybox
+    # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/latest-1/musl/busybox.tar.xz
     # Update the sha256 value. Since github api doesn't give sha256 value, it can be obtained using sha256sum command.
     http_file(
         name = "busybox_arm64",
         executable = True,
-        sha256 = "02033a50ef38a32a72b4b28183654116c42dae61ec9dccb349f9f63c6ae30f53",
-        urls = ["https://github.com/docker-library/busybox/raw/22bb23a2665eefb1520dc4c99d5ac9bdf87ae93b/stable/musl/busybox.tar.xz"],
+        sha256 = "2441ebc513f4a9d49e3f8e82a71ebc039cc330c611323eb2e11cc960f4ca83c3",
+        urls = ["https://github.com/docker-library/busybox/raw/905f4a7acda06df4b1d1884bd25f98f522f5afa8/latest-1/musl/busybox.tar.xz"],
     )
 
     http_file(
@@ -39,12 +41,13 @@ def repositories():
     )
 
     # To update ppc64le busybox binary (#723)
-    # Get the latest commit hash from dist-ppc64le branch of docker-library repo.
-    # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/stable/musl/busybox.tar.xz
+    # Get the latest commit hash from dist-ppc64le branch of docker-library repo. You can also view it
+    # at https://github.com/docker-library/official-images/blob/master/library/busybox
+    # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/latest-1/musl/busybox.tar.xz
     # Update the sha256 value. Since github api doesn't give sha256 value, it can be obtained using sha256sum command.
     http_file(
         name = "busybox_ppc64le",
         executable = True,
-        sha256 = "469297ea9293df0dcb6c3f8d344eaf9f9b6ec1732696ffe86994f87c3600423b",
-        urls = ["https://github.com/docker-library/busybox/raw/c0125333c4c3dfa4b9e5fd9fe6fbb875242f3613/stable/musl/busybox.tar.xz"],
+        sha256 = "6b453957c98455b8e7ea3bf55e2f20888317100a597b76b6cab590c4a9412103",
+        urls = ["https://github.com/docker-library/busybox/raw/1a8d828e317a782249cb83ca3bae442b48f5f41c/latest-1/musl/busybox.tar.xz"],
     )


### PR DESCRIPTION


This is an update to busybox to [1.35.0](https://github.com/docker-library/official-images/blob/master/library/busybox). 

I was hoping to upgrade it to `1.36.0` or higher to get rid of this [CVE](https://nvd.nist.gov/vuln/detail/CVE-2022-28391) but unfortunately that is still marked as `unstable` in the docker-library tag list so seems "unwise".  `1.35.0` also matches alpine's currently used version

<img width="934" alt="image" src="https://user-images.githubusercontent.com/10355001/235619683-ece376ca-83f8-4217-9def-95c0eb83cdc9.png">

Busybox themselves [seems to have marked their last stable release as 1.34.1](https://busybox.net/news.html) in 2021 so it's possible I'm mistaken here and we want to for stability sake leave this as `1.34.1` and close this mr. 
