### PR TITLE
Update BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -217,7 +217,7 @@ NODEJS = {
 }
 
 # oci_image_index
-NODEJS = {
+NODEJS |= {
     "{REGISTRY}/{PROJECT_ID}/nodejs" + version + "-" + distro + ":" + tag_base: "//nodejs:nodejs" + version + label + "_" + user + "_" + distro
     for distro in LANGUAGE_DISTROS
     for version in NODEJS_VERSIONS


### PR DESCRIPTION
Node tags with architecture were missing.

@omBratteng fyi, I think I'll just update this here for now.
@mnacken fyi, this should fix your issues with architecture specific tags