### PR TITLE
Fix update when no snapshot exists for this month

### DIFF
--- a/debian_package_manager/internal/deb/snapshot.go
+++ b/debian_package_manager/internal/deb/snapshot.go
@@ -68,7 +68,7 @@ func latest(urltemplate string) (string, error) {
 }
 
 func latestFromUrl(snapshotURL string) (string, error) {
-	resp, err := http.Get(snapshotURL)
+	resp, err := rhttp.Get(snapshotURL)
 	if err != nil {
 		return "", err
 	}

--- a/debian_package_manager/internal/deb/snapshot.go
+++ b/debian_package_manager/internal/deb/snapshot.go
@@ -55,7 +55,20 @@ var (
 func latest(urltemplate string) (string, error) {
 	year, month, _ := time.Now().Date()
 	snapshotURL := fmt.Sprintf(urltemplate, year, month)
-	resp, err := rhttp.Get(snapshotURL)
+	resp, err := latestFromUrl(snapshotURL)
+	if err != nil {
+		snapshotURL1 := fmt.Sprintf(urltemplate, year, month - 1)
+		resp1, err1 := latestFromUrl(snapshotURL1)
+		if err1 != nil {
+			return "", err1
+		}
+		return resp1, err1
+	}
+	return resp, err
+}
+
+func latestFromUrl(snapshotURL string) (string, error) {
+	resp, err := http.Get(snapshotURL)
 	if err != nil {
 		return "", err
 	}

--- a/debian_package_manager/internal/deb/snapshot.go
+++ b/debian_package_manager/internal/deb/snapshot.go
@@ -57,7 +57,13 @@ func latest(urltemplate string) (string, error) {
 	snapshotURL := fmt.Sprintf(urltemplate, year, month)
 	resp, err := latestFromUrl(snapshotURL)
 	if err != nil {
-		snapshotURL1 := fmt.Sprintf(urltemplate, year, month - 1)
+		if month == 1 {
+			year = year - 1
+			month = 12
+		} else {
+			month = month - 1
+		}
+		snapshotURL1 := fmt.Sprintf(urltemplate, year, month)
 		resp1, err1 := latestFromUrl(snapshotURL1)
 		if err1 != nil {
 			return "", err1


### PR DESCRIPTION
I noticed that the update was not working on 1st of June because there is/was a "404 Not Found" error at least until 17:30 CET when requesting https://snapshot.debian.org/archive/debian/?year=2023&month=6.