### PR TITLE
fix tar on deb format file in locale

### DIFF
--- a/locale/locale.bzl
+++ b/locale/locale.bzl
@@ -16,8 +16,10 @@ def _impl(ctx):
         ],
         command = """
         set -o pipefail -o errexit -o nounset
+        ar -x "$1" data.tar.xz
         tmp=$(mktemp -d)
-        tar -xf "$1" -C "$tmp" ./usr/lib/locale/C.UTF-8 ./usr/share/doc/libc-bin/copyright
+        tar -xf data.tar.xz -C "$tmp" ./usr/lib/locale/C.UTF-8 ./usr/share/doc/libc-bin/copyright
+        rm data.tar.xz
         cp -r "$tmp/usr/lib/locale/C.UTF-8/." $2
         mv "$tmp/usr/share/doc/libc-bin/copyright" $3
         """,

--- a/locale/locale.bzl
+++ b/locale/locale.bzl
@@ -16,10 +16,9 @@ def _impl(ctx):
         ],
         command = """
         set -o pipefail -o errexit -o nounset
-        ar -x "$1" data.tar.xz
         tmp=$(mktemp -d)
-        tar -xf data.tar.xz -C "$tmp" ./usr/lib/locale/C.UTF-8 ./usr/share/doc/libc-bin/copyright
-        rm data.tar.xz
+        ar -x "$1" --output "$tmp" data.tar.xz
+        tar -xf "$tmp/data.tar.xz" -C "$tmp" ./usr/lib/locale/C.UTF-8 ./usr/share/doc/libc-bin/copyright
         cp -r "$tmp/usr/lib/locale/C.UTF-8/." $2
         mv "$tmp/usr/share/doc/libc-bin/copyright" $3
         """,


### PR DESCRIPTION
Argument 1 is the deb file, it should translate into tar format, then apply the tar command to extract the expected files.
Otherwise, errors are like followings:

```
tar: This does not look like a tar archive
tar: Skipping to next header
tar: ./usr/lib/locale/C.UTF-8: Not found in archive
tar: ./usr/share/doc/libc-bin/copyright: Not found in archive
tar: Exiting with failure status due to previous errors
```