### PR TITLE
draft: feature: add bookworm 12

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,7 @@ STATIC_VARIANTS = [
 STATIC = {
     "{REGISTRY}/{PROJECT_ID}/static:{COMMIT_SHA}": "//base:static_root_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/static-debian11:{COMMIT_SHA}": "//base:static_root_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/static-debian12:{COMMIT_SHA}": "//base:static_root_amd64_debian12",
 }
 
 STATIC |= {
@@ -54,6 +55,7 @@ BASE_VARIANTS = [
 BASE = {
     "{REGISTRY}/{PROJECT_ID}/base:{COMMIT_SHA}": "//base:base_root_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/base-debian11:{COMMIT_SHA}": "//base:base_root_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/base-debian12:{COMMIT_SHA}": "//base:base_root_amd64_debian12",
 }
 
 BASE |= {
@@ -93,6 +95,7 @@ BASE_NOSSL_VARIANTS = [
 BASE_NOSSL = {
     "{REGISTRY}/{PROJECT_ID}/base-nossl:{COMMIT_SHA}": "//base:base_nossl_root_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/base-nossl-debian11:{COMMIT_SHA}": "//base:base_nossl_root_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/base-nossl-debian12:{COMMIT_SHA}": "//base:base_nossl_root_amd64_debian12",
 }
 
 BASE_NOSSL |= {
@@ -132,6 +135,8 @@ CC_VARIANTS = [
 CC = {
     "{REGISTRY}/{PROJECT_ID}/cc:{COMMIT_SHA}": "//cc:cc_root_amd64_debian11",
     "{REGISTRY}/{PROJECT_ID}/cc-debian11:{COMMIT_SHA}": "//cc:cc_root_amd64_debian11",
+    "{REGISTRY}/{PROJECT_ID}/cc-debian12:{COMMIT_SHA}": "//cc:cc_root_amd64_debian12",
+
 }
 
 CC |= {

--- a/base/distro.bzl
+++ b/base/distro.bzl
@@ -1,4 +1,4 @@
-DISTROS = ["debian11"]
+DISTROS = ["debian11", "debian12"]
 
 # language images (java, node, python, etc) have shorter support windows
 # see SUPPORT_POLICY.md

--- a/base/testdata/debian12.yaml
+++ b/base/testdata/debian12.yaml
@@ -1,0 +1,5 @@
+schemaVersion: "1.0.0"
+fileContentTests:
+- name: 'os-release contents'
+  path: '/etc/os-release'
+  expectedContents: ['.*\nVERSION="Debian GNU/Linux 12 \(bookworm\)"\n']

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -10,6 +10,9 @@ DISTRO_DEBS = {
     "debian11": [
         "libgcc-s1",
     ],
+    "debian12": [
+        "libgcc-s1",
+    ],
 }
 
 # An image for C/C++ programs

--- a/debian_package_manager/internal/build/config/distros.go
+++ b/debian_package_manager/internal/build/config/distros.go
@@ -24,9 +24,10 @@ type Distro int64
 const (
 	DEBIAN10 Distro = iota
 	DEBIAN11
+	DEBIAN12
 )
 
-var distros = []Distro{DEBIAN10, DEBIAN11}
+var distros = []Distro{DEBIAN10, DEBIAN11, DEBIAN12}
 
 func (d Distro) String() string {
 	switch d {
@@ -34,6 +35,8 @@ func (d Distro) String() string {
 		return "debian10"
 	case DEBIAN11:
 		return "debian11"
+	case DEBIAN11:
+		return "debian12"
 	}
 	panic("unknown release")
 }
@@ -44,6 +47,8 @@ func (d Distro) Version() int {
 		return 10
 	case DEBIAN11:
 		return 11
+	case DEBIAN11:
+		return 12
 	}
 	panic("unknown release")
 }
@@ -53,6 +58,8 @@ func (d Distro) Codename() string {
 	case DEBIAN10:
 		return "buster"
 	case DEBIAN11:
+		return "bullseye"
+	case DEBIAN12:
 		return "bullseye"
 	}
 	panic("unknown release")

--- a/debian_package_manager/internal/build/config/distros.go
+++ b/debian_package_manager/internal/build/config/distros.go
@@ -35,7 +35,7 @@ func (d Distro) String() string {
 		return "debian10"
 	case DEBIAN11:
 		return "debian11"
-	case DEBIAN11:
+	case DEBIAN12:
 		return "debian12"
 	}
 	panic("unknown release")
@@ -47,7 +47,7 @@ func (d Distro) Version() int {
 		return 10
 	case DEBIAN11:
 		return 11
-	case DEBIAN11:
+	case DEBIAN12:
 		return 12
 	}
 	panic("unknown release")

--- a/debian_packages.yaml
+++ b/debian_packages.yaml
@@ -1,12 +1,11 @@
-# debian 11
-- distros: ["debian11"]
-  archs: ["amd64", "arm64", "arm", "s390x", "ppc64le"]
+# debian 11 + 12
+- distros: ["debian11", "debian12"]
+  archs: ["amd64"]
   packages:
     - "base-files"
     - "ca-certificates"
     - "libc6"
     - "libc-bin"
-    - "libssl1.1"
     - "netbase"
     - "openssl"
     - "tzdata"
@@ -15,59 +14,72 @@
     - "libgomp1"
     - "libstdc++6"
 
-# debian 11, limited architectures, java only
+# debian 11
 - distros: ["debian11"]
-  archs: ["amd64", "arm64", "s390x", "ppc64le"]
+  archs: ["amd64"]
   packages:
-    - "fontconfig-config"
-    - "fonts-dejavu-core"
-    - "libbrotli1"
-    - "libcrypt1" # TODO: glibc library for -lcrypt; maybe should be in cc?
-    - "libexpat1"
-    - "libfontconfig1"
-    - "libfreetype6"
-    - "libglib2.0-0"
-    - "libgraphite2-3"
-    - "libharfbuzz0b"
-    - "libjpeg62-turbo"
-    - "liblcms2-2"
-    - "libpcre3"
-    - "libpng16-16"
-    - "libuuid1"
-    - "openjdk-11-jdk-headless"
-    - "openjdk-11-jre-headless"
-    - "openjdk-17-jdk-headless"
-    - "openjdk-17-jre-headless"
-    - "zlib1g"
+    - "libssl1.1"
 
-# debian 11, limited architectures, python only
-- distros: ["debian11"]
-  archs: ["amd64", "arm64"]
+# debian 12
+- distros: ["debian12"]
+  archs: ["amd64"]
   packages:
-    - "dash"
-    - "libbz2-1.0"
-    - "libcom-err2"
-    - "libcrypt1" # TODO: glibc library for -lcrypt; maybe should be in cc?
-    - "libdb5.3"
-    - "libexpat1"
-    - "libffi7"
-    - "libgssapi-krb5-2"
-    - "libk5crypto3"
-    - "libkeyutils1"
-    - "libkrb5-3"
-    - "libkrb5support0"
-    - "liblzma5"
-    - "libmpdec3"
-    - "libncursesw6"
-    - "libnsl2"
-    - "libpython3.9-minimal"
-    - "libpython3.9-stdlib"
-    - "libreadline8"
-    - "libsqlite3-0"
-    - "libtinfo6"
-    - "libtirpc3"
-    - "libuuid1"
-    - "python3-distutils"
-    - "python3.9-minimal"
-    - "zlib1g"
+    - "libssl3"
+
+# # debian 11, limited architectures, java only
+# - distros: ["debian11"]
+#   archs: ["amd64"]
+#   packages:
+#     - "fontconfig-config"
+#     - "fonts-dejavu-core"
+#     - "libbrotli1"
+#     - "libcrypt1" # TODO: glibc library for -lcrypt; maybe should be in cc?
+#     - "libexpat1"
+#     - "libfontconfig1"
+#     - "libfreetype6"
+#     - "libglib2.0-0"
+#     - "libgraphite2-3"
+#     - "libharfbuzz0b"
+#     - "libjpeg62-turbo"
+#     - "liblcms2-2"
+#     - "libpcre3"
+#     - "libpng16-16"
+#     - "libuuid1"
+#     - "openjdk-11-jdk-headless"
+#     - "openjdk-11-jre-headless"
+#     - "openjdk-17-jdk-headless"
+#     - "openjdk-17-jre-headless"
+#     - "zlib1g"
+
+
+# # debian 11, limited architectures, python only
+# - distros: ["debian11"]
+#   archs: ["amd64"]
+#   packages:
+#     - "dash"
+#     - "libbz2-1.0"
+#     - "libcom-err2"
+#     - "libcrypt1" # TODO: glibc library for -lcrypt; maybe should be in cc?
+#     - "libdb5.3"
+#     - "libexpat1"
+#     - "libffi7"
+#     - "libgssapi-krb5-2"
+#     - "libk5crypto3"
+#     - "libkeyutils1"
+#     - "libkrb5-3"
+#     - "libkrb5support0"
+#     - "liblzma5"
+#     - "libmpdec3"
+#     - "libncursesw6"
+#     - "libnsl2"
+#     - "libpython3.9-minimal"
+#     - "libpython3.9-stdlib"
+#     - "libreadline8"
+#     - "libsqlite3-0"
+#     - "libtinfo6"
+#     - "libtirpc3"
+#     - "libuuid1"
+#     - "python3-distutils"
+#     - "python3.9-minimal"
+#     - "zlib1g"
 


### PR DESCRIPTION
This feature will try to enable distroless 12.

This tries to re-implement:

https://github.com/GoogleContainerTools/distroless/pull/1146