### PR TITLE
Revert io_bazel_rules_go to v0.35.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,10 +39,10 @@ http_archive(
 # rules_go setup
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
+    sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
     ],
 )
 
@@ -50,7 +50,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.21.0")
+go_register_toolchains(version = "1.19.1")
 
 http_archive(
     name = "bazel_gazelle",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,7 @@ http_archive(
 )
 
 # rules_go setup
+# NOTE: cannot upgrade past v0.35.0 until https://github.com/bazelbuild/rules_go/issues/3531 is resolved.
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",


### PR DESCRIPTION
Fixes #1381

[rules_go](https://github.com/bazelbuild/rules_go) is broken for the ppc64le arch since version v0.36.0 which introduced [this change](https://github.com/bazelbuild/rules_go/pull/3336).

Until https://github.com/bazelbuild/rules_go/issues/3531 is resolved a good workaround is to revert to v0.35.0.
