### PR TITLE
Drop node16

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -200,7 +200,6 @@ PYTHON3 |= {
 
 ## NODEJS
 NODEJS_VERSIONS = [
-    "16",
     "18",
     "20",
 ]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These images are built using [bazel](https://bazel.build), but they can also be 
 The following images are currently published and updated by the distroless project (see [SUPPORT_POLICY]([url](https://github.com/GoogleContainerTools/distroless/blob/main/SUPPORT_POLICY.md)) for support timelines)
 
 #### Debian 12
-| Image                                 | Tags                                   | Architecture Suffixes             | 
+| Image                                 | Tags                                   | Architecture Suffixes             |
 | ---                                   | ---                                    | ---                               |
 | gcr.io/distroless/static-debian12     | latest, nonroot, debug, debug-nonroot  | amd64, arm64, arm, s390x, ppc64le |
 | gcr.io/distroless/base-debian12       | latest, nonroot, debug, debug-nonroot  | amd64, arm64, arm, s390x, ppc64le |
@@ -47,7 +47,6 @@ The following images are currently published and updated by the distroless proje
 | gcr.io/distroless/java-base-debian11  | latest, nonroot, debug, debug-nonroot  | amd64, arm64, s390x, ppc64le      |
 | gcr.io/distroless/java11-debian11     | latest, nonroot, debug, debug-nonroot  | amd64, arm64, s390x, ppc64le      |
 | gcr.io/distroless/java17-debian11     | latest, nonroot, debug, debug-nonroot  | amd64, arm64, s390x, ppc64le      |
-| gcr.io/distroless/nodejs16-debian11   | latest, nonroot, debug, debug-nonroot  | amd64, arm64                      |
 | gcr.io/distroless/nodejs18-debian11   | latest, nonroot, debug, debug-nonroot  | amd64, arm64                      |
 | gcr.io/distroless/nodejs20-debian11   | latest, nonroot, debug, debug-nonroot  | amd64, arm64                      |
 
@@ -117,7 +116,6 @@ Follow these steps to get started:
     * [gcr.io/distroless/java17-debian11](java/README.md)
     * [gcr.io/distroless/cc-debian12](cc/README.md)
     * [gcr.io/distroless/cc-debian11](cc/README.md)
-    * [gcr.io/distroless/nodejs16-debian11](nodejs/README.md)
     * [gcr.io/distroless/nodejs18-debian11](nodejs/README.md)
     * [gcr.io/distroless/nodejs20-debian11](nodejs/README.md)
 

--- a/SUPPORT_POLICY.md
+++ b/SUPPORT_POLICY.md
@@ -21,7 +21,7 @@ The current estimation of end of life for images with the pattern:
 Java will only support current LTS version distributed by debian [see here](https://wiki.debian.org/Java).
 
 ### Node
-Node version support is for even numbered releases (16, 18, 20, etc) that are current, active or in LTS maintenance. For more information, [see here](https://nodejs.org/en/about/releases/).
+Node version support is for even numbered releases (18, 20, etc) that are current, active or in LTS maintenance. For more information, [see here](https://nodejs.org/en/about/releases/).
 
 ### Python
 Python support is experimental, and this project does not make any guarantees about the version of python in images.

--- a/examples/nodejs/BUILD
+++ b/examples/nodejs/BUILD
@@ -28,7 +28,7 @@ pkg_tar(
 [
     oci_image(
         name = "hello_" + user + "_" + arch + "_" + distro,
-        base = "//nodejs:nodejs16_" + user + "_" + arch + "_" + distro,
+        base = "//nodejs:nodejs18_" + user + "_" + arch + "_" + distro,
         cmd = ["hello.js"],
         tars = [":hello_tar"],
     )
@@ -43,7 +43,7 @@ pkg_tar(
 [
     oci_image(
         name = "hello_http_" + user + "_" + arch + "_" + distro,
-        base = "//nodejs:nodejs16_" + user + "_" + arch + "_" + distro,
+        base = "//nodejs:nodejs18_" + user + "_" + arch + "_" + distro,
         cmd = ["hello_http.js"],
         tars = [":hello_http_tar"],
     )

--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -5,16 +5,6 @@ def repositories():
     # Follow Node's maintainence schedule and support all LTS versions that are not end of life
 
     node_archive(
-        name = "nodejs16_amd64",
-        sha256 = "c9193e6c414891694759febe846f4f023bf48410a6924a8b1520c46565859665",
-        strip_prefix = "node-v16.20.2-linux-x64/",
-        urls = ["https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.gz"],
-        version = "16.20.2",
-        architecture = "amd64",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
         name = "nodejs18_amd64",
         sha256 = "2cb75f2bc04b0a3498733fbee779b2f76fe3f655188b4ac69ef2887b6721da2d",
         strip_prefix = "node-v18.17.1-linux-x64/",
@@ -31,16 +21,6 @@ def repositories():
         urls = ["https://nodejs.org/dist/v20.6.0/node-v20.6.0-linux-x64.tar.gz"],
         version = "20.6.0",
         architecture = "amd64",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs16_arm64",
-        sha256 = "b6945fcc9ad220386bb814bfae7137189fd17297f2959a744105e1bee006035a",
-        strip_prefix = "node-v16.20.2-linux-arm64/",
-        urls = ["https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-arm64.tar.gz"],
-        version = "16.20.2",
-        architecture = "arm64",
         control = "//nodejs:control",
     )
 

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -5,7 +5,7 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])
 
-NODEJS_MAJOR_VERISONS = ("16", "18", "20")
+NODEJS_MAJOR_VERISONS = ("18", "20")
 
 MODE = [
     "",

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -6,7 +6,6 @@ These images contain a minimal Linux, Node.js-based runtime. The supported versi
 
 Specifically, these images contain everything in the [base image](../base/README.md), plus one of:
 
-- Node.js v16 (`gcr.io/distroless/nodejs16-debian11`) and its dependencies.
 - Node.js v18 (`gcr.io/distroless/nodejs18-debian11`) and its dependencies.
 - Node.js v20 (`gcr.io/distroless/nodejs20-debian11`) and its dependencies.
 

--- a/nodejs/testdata/nodejs16.yaml
+++ b/nodejs/testdata/nodejs16.yaml
@@ -1,6 +1,0 @@
-schemaVersion: "2.0.0"
-commandTests:
-  - name: nodejs
-    command: "/nodejs/bin/node"
-    args: ["--version"]
-    expectedOutput: ['v16.20.2']


### PR DESCRIPTION
It reaches EOL on monday ([2023-09-11](https://nodejs.org/en/blog/announcements/nodejs16-eol)), and is no longer supported.