### PR TITLE
feat: Add Node.js support for Debian 12

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -214,7 +214,7 @@ NODEJS_VARIATIONS = [
 NODEJS = {
     "{REGISTRY}/{PROJECT_ID}/nodejs" + version + "-" + distro + ":" + tag_base + "-" + arch: "//nodejs:nodejs" + version + label + "_" + user + "_" + arch + "_" + distro
     for arch in BASE_ARCHITECTURES
-    for distro in LANGUAGE_DISTROS
+    for distro in DISTROS
     for version in NODEJS_VERSIONS
     for (tag_base, label, user) in NODEJS_VARIATIONS
 }
@@ -222,7 +222,7 @@ NODEJS = {
 # oci_image_index
 NODEJS |= {
     "{REGISTRY}/{PROJECT_ID}/nodejs" + version + "-" + distro + ":" + tag_base: "//nodejs:nodejs" + version + label + "_" + user + "_" + distro
-    for distro in LANGUAGE_DISTROS
+    for distro in DISTROS
     for version in NODEJS_VERSIONS
     for (tag_base, label, user) in NODEJS_VARIATIONS
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,9 @@ oci_tarball(
 )
 ```
 then build the tarball and load it into docker
-```
+```shell
 bazel build //:local_build
-docker load --input $(bazel cquery --output=files //local_build))
+docker load --input $(bazel cquery --output=files //:local_build)
 ```
 
 ## Code style

--- a/examples/nodejs/BUILD
+++ b/examples/nodejs/BUILD
@@ -3,7 +3,7 @@
 # repository code at any time.
 load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "structure_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("//base:distro.bzl", DISTROS = "LANGUAGE_DISTROS")
+load("//base:distro.bzl", "DISTROS")
 load("//:checksums.bzl", ARCHITECTURES = "BASE_ARCHITECTURES")
 
 package(default_visibility = ["//visibility:public"])

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -1,4 +1,4 @@
-load("//base:distro.bzl", DISTROS = "LANGUAGE_DISTROS")
+load("//base:distro.bzl", "DISTROS")
 load("//:checksums.bzl", ARCHITECTURES = "BASE_ARCHITECTURES")
 load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "structure_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")


### PR DESCRIPTION
This pull request adds Node.js (v18, v20) language support for Debian 12 (bookworm).
References #1398.