### PR TITLE
docs: Add Debian 12 language supports in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The following images are currently published and updated by the distroless proje
 | gcr.io/distroless/base-debian12       | latest, nonroot, debug, debug-nonroot  | amd64, arm64, arm, s390x, ppc64le |
 | gcr.io/distroless/base-nossl-debian12 | latest, nonroot, debug, debug-nonroot  | amd64, arm64, arm, s390x, ppc64le |
 | gcr.io/distroless/cc-debian12         | latest, nonroot, debug, debug-nonroot  | amd64, arm64, arm, s390x, ppc64le |
+| gcr.io/distroless/python3-debian12    | latest, nonroot, debug, debug-nonroot  | amd64, arm64                      |
+| gcr.io/distroless/java-base-debian12  | latest, nonroot, debug, debug-nonroot  | amd64, arm64, s390x, ppc64le      |
+| gcr.io/distroless/java11-debian12     | latest, nonroot, debug, debug-nonroot  | amd64, arm64, s390x, ppc64le      |
+| gcr.io/distroless/java17-debian12     | latest, nonroot, debug, debug-nonroot  | amd64, arm64, s390x, ppc64le      |
+| gcr.io/distroless/nodejs18-debian12   | latest, nonroot, debug, debug-nonroot  | amd64, arm64                      |
+| gcr.io/distroless/nodejs20-debian12   | latest, nonroot, debug, debug-nonroot  | amd64, arm64                      |
 
 #### Debian 11
 | Image                                 | Tags                                   | Architecture Suffixes             |
@@ -112,14 +118,19 @@ Follow these steps to get started:
     * [gcr.io/distroless/base-nossl-debian11](base/README.md)
     * [gcr.io/distroless/base-debian12](base/README.md)
     * [gcr.io/distroless/base-debian11](base/README.md)
+    * [gcr.io/distroless/java11-debian12](java/README.md)
     * [gcr.io/distroless/java11-debian11](java/README.md)
+    * [gcr.io/distroless/java17-debian12](java/README.md)
     * [gcr.io/distroless/java17-debian11](java/README.md)
     * [gcr.io/distroless/cc-debian12](cc/README.md)
     * [gcr.io/distroless/cc-debian11](cc/README.md)
+    * [gcr.io/distroless/nodejs18-debian12](nodejs/README.md)
     * [gcr.io/distroless/nodejs18-debian11](nodejs/README.md)
+    * [gcr.io/distroless/nodejs20-debian12](nodejs/README.md)
     * [gcr.io/distroless/nodejs20-debian11](nodejs/README.md)
 
 * The following images are also published on `gcr.io`, but are considered experimental and not recommended for production usage:
+    * [gcr.io/distroless/python3-debian12](experimental/python3/README.md)
     * [gcr.io/distroless/python3-debian11](experimental/python3/README.md)
 * Write a multi-stage docker file.
   Note: This requires Docker 17.05 or higher.

--- a/java/README.md
+++ b/java/README.md
@@ -6,8 +6,8 @@ This image contains a minimal Linux, OpenJDK-based runtime.
 
 Specifically, the image contains everything in the [base image](../base/README.md), plus:
 
-* OpenJDK 11 (`gcr.io/distroless/java11-debian11`) and its dependencies.
-* OpenJDK 17 (`gcr.io/distroless/java17-debian11`) and its dependencies.
+* OpenJDK 11 (`gcr.io/distroless/java11-debian12`, `gcr.io/distroless/java11-debian11`) and its dependencies.
+* OpenJDK 17 (`gcr.io/distroless/java17-debian12`, `gcr.io/distroless/java17-debian11`) and its dependencies.
 
 
 ## Usage

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -6,8 +6,8 @@ These images contain a minimal Linux, Node.js-based runtime. The supported versi
 
 Specifically, these images contain everything in the [base image](../base/README.md), plus one of:
 
-- Node.js v18 (`gcr.io/distroless/nodejs18-debian11`) and its dependencies.
-- Node.js v20 (`gcr.io/distroless/nodejs20-debian11`) and its dependencies.
+- Node.js v18 (`gcr.io/distroless/nodejs18-debian12`, `gcr.io/distroless/nodejs18-debian11`) and its dependencies.
+- Node.js v20 (`gcr.io/distroless/nodejs20-debian12`, `gcr.io/distroless/nodejs20-debian11`) and its dependencies.
 
 ## Usage
 


### PR DESCRIPTION
This pull request adds image URIs in README.md for the Debian 12 language support images added by #1397, #1402, and #1403. I think we can close #1398 after merging this.