### PR TITLE
Add Teleport as a Distroless user

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ BUILD       Dockerfile  hello.py
 - [Kubernetes](https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/1729-rebase-images-to-distroless/README.md), since v1.15
 - [Knative](https://knative.dev)
 - [Tekton](https://tekton.dev)
+- [Teleport](https://goteleport.com)
 
 If your project uses Distroless, send a PR to add your project here!
 


### PR DESCRIPTION
Teleport uses Distroless since Teleport 13 for its recommended images.

https://goteleport.com/docs/changelog/#helm-chart-uses-distroless-based-container-image-by-default