### PR TITLE
Bump `nodejs18` to `18.18.2` and `nodejs20` to `20.8.1`

### DIFF
--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -16,10 +16,10 @@ def repositories():
 
     node_archive(
         name = "nodejs20_amd64",
-        sha256 = "ae6f288a21a3bc7a82b79d3f00c52216df6de09c45eac0ea754243a9c7fb5e69",
-        strip_prefix = "node-v20.8.0-linux-x64/",
-        urls = ["https://nodejs.org/dist/v20.8.0/node-v20.8.0-linux-x64.tar.gz"],
-        version = "20.8.0",
+        sha256 = "a42ac1f81704b14c7d07ddde989a8e290087b0487ee3f47185eb0240ba518195",
+        strip_prefix = "node-v20.8.1-linux-x64/",
+        urls = ["https://nodejs.org/dist/v20.8.1/node-v20.8.1-linux-x64.tar.gz"],
+        version = "20.8.1",
         architecture = "amd64",
         control = "//nodejs:control",
     )

--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -26,10 +26,10 @@ def repositories():
 
     node_archive(
         name = "nodejs18_arm64",
-        sha256 = "1d3ef02cfefc9c87a010ec9ac9a21cafc71096e8159b9f35b419d6e5f71e2f92",
-        strip_prefix = "node-v18.18.1-linux-arm64/",
-        urls = ["https://nodejs.org/dist/v18.18.1/node-v18.18.1-linux-arm64.tar.gz"],
-        version = "18.18.1",
+        sha256 = "0c9a6502b66310cb26e12615b57304e91d92ac03d4adcb91c1906351d7928f0d",
+        strip_prefix = "node-v18.18.2-linux-arm64/",
+        urls = ["https://nodejs.org/dist/v18.18.2/node-v18.18.2-linux-arm64.tar.gz"],
+        version = "18.18.2",
         architecture = "arm64",
         control = "//nodejs:control",
     )

--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -36,10 +36,10 @@ def repositories():
 
     node_archive(
         name = "nodejs20_arm64",
-        sha256 = "cec9be5a060f63bfda7ef5b5a368cba5cfa0ce673b117bae8c146ec5df767cbe",
-        strip_prefix = "node-v20.8.0-linux-arm64/",
-        urls = ["https://nodejs.org/dist/v20.8.0/node-v20.8.0-linux-arm64.tar.gz"],
-        version = "20.8.0",
+        sha256 = "c0420fef5f6e637888be3f400e99297bb844932166fbad5ffa4f188ce59cfcdf",
+        strip_prefix = "node-v20.8.1-linux-arm64/",
+        urls = ["https://nodejs.org/dist/v20.8.1/node-v20.8.1-linux-arm64.tar.gz"],
+        version = "20.8.1",
         architecture = "arm64",
         control = "//nodejs:control",
     )

--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -6,10 +6,10 @@ def repositories():
 
     node_archive(
         name = "nodejs18_amd64",
-        sha256 = "9ce4db11f1d8399f6b58aab6858a688b2e09405127b47ebc4594dc8262a5e29f",
-        strip_prefix = "node-v18.18.1-linux-x64/",
-        urls = ["https://nodejs.org/dist/v18.18.1/node-v18.18.1-linux-x64.tar.gz"],
-        version = "18.18.1",
+        sha256 = "a44c3e7f8bf91e852c928e5d8bd67ca316b35e27eec1d8acbe3b9dbe03688dab",
+        strip_prefix = "node-v18.18.2-linux-x64/",
+        urls = ["https://nodejs.org/dist/v18.18.2/node-v18.18.2-linux-x64.tar.gz"],
+        version = "18.18.2",
         architecture = "amd64",
         control = "//nodejs:control",
     )

--- a/nodejs/testdata/nodejs18.yaml
+++ b/nodejs/testdata/nodejs18.yaml
@@ -3,4 +3,4 @@ commandTests:
   - name: nodejs
     command: "/nodejs/bin/node"
     args: ["--version"]
-    expectedOutput: ["v18.18.1"]
+    expectedOutput: ["v18.18.2"]

--- a/nodejs/testdata/nodejs20.yaml
+++ b/nodejs/testdata/nodejs20.yaml
@@ -3,4 +3,4 @@ commandTests:
   - name: nodejs
     command: "/nodejs/bin/node"
     args: ["--version"]
-    expectedOutput: ["v20.8.0"]
+    expectedOutput: ["v20.8.1"]


### PR DESCRIPTION
Security fixes part of https://nodejs.org/en/blog/vulnerability/october-2023-security-releases