### PR TITLE
resolves #1409 to note that Python on Debian 12 is out of experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ ENTRYPOINT "myapp"
 ```
 
 For the same reasons, if the entrypoint is set to the empty vector, the CMD command should be specified in `vector` form (see examples below).
-Note that by default static, base and cc images have the empty vector entrypoint. Images with an included language runtime have a language specific default (see: [java](java/README.md#usage), [nodejs](nodejs/README.md#usage), [python3](experimental/python3/README.md#usage)).
+Note that by default static, base and cc images have the empty vector entrypoint. Images with an included language runtime have a language specific default (see: [java](java/README.md#usage), [nodejs](nodejs/README.md#usage), [python3](python3/README.md#usage)).
 
 ### Docker
 
@@ -126,9 +126,8 @@ Follow these steps to get started:
     * [gcr.io/distroless/nodejs18-debian11](nodejs/README.md)
     * [gcr.io/distroless/nodejs20-debian12](nodejs/README.md)
     * [gcr.io/distroless/nodejs20-debian11](nodejs/README.md)
-
+    * [gcr.io/distroless/python3-debian12](python3/README.md)
 * The following images are also published on `gcr.io`, but are considered experimental and not recommended for production usage:
-    * [gcr.io/distroless/python3-debian12](experimental/python3/README.md)
     * [gcr.io/distroless/python3-debian11](experimental/python3/README.md)
 * Write a multi-stage docker file.
   Note: This requires Docker 17.05 or higher.
@@ -228,7 +227,7 @@ cd examples/python3/
 edit the ```Dockerfile``` to change the final image to ```:debug```:
 
 ```dockerfile
-FROM gcr.io/distroless/python3-debian11:debug
+FROM gcr.io/distroless/python3-debian12:debug
 COPY . /app
 WORKDIR /app
 CMD ["hello.py", "/etc"]

--- a/SUPPORT_POLICY.md
+++ b/SUPPORT_POLICY.md
@@ -23,8 +23,8 @@ Java will only support current LTS version distributed by debian [see here](http
 ### Node
 Node version support is for even numbered releases (18, 20, etc) that are current, active or in LTS maintenance. For more information, [see here](https://nodejs.org/en/about/releases/).
 
-### Python
-Python support is experimental, and this project does not make any guarantees about the version of python in images.
+### Python on Debian 11
+Python on Debian 11 support is experimental, and this project does not make any guarantees about the version of python in images.
 
 ### Images no longer supported (TBD)
 A list of supported image tags is available here: https://github.com/GoogleContainerTools/distroless#what-images-are-available

--- a/examples/python3/BUILD
+++ b/examples/python3/BUILD
@@ -14,7 +14,7 @@ pkg_tar(
 [
     oci_image(
         name = "hello_" + distro,
-        base = "//experimental/python3:python3_root_arm64_" + distro,
+        base = "//python3:python3_root_arm64_" + distro,
         cmd = [
             "hello.py",
             "/etc",


### PR DESCRIPTION
resolves #1409 to note that Python on Debian 12 is out of experimental while it is still built for Debian 11 from experimental. Another PR would need to move all of Python builds out of experimental.

Update:
* README
* Support Policy
* Examples

I am focusing on the Debian 12 Python topic, the Debian 11 Python is still in the experimental builds.