### PR TITLE
doc: fix node js release url

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -2,7 +2,7 @@
 
 ## Image Contents
 
-These images contain a minimal Linux, Node.js-based runtime. The supported versions match the [Node.js LTS releases](https://nodejs.org/en/about/releases/).
+These images contain a minimal Linux, Node.js-based runtime. The supported versions match the [Node.js LTS releases](https://nodejs.org/en/about/previous-releases).
 
 Specifically, these images contain everything in the [base image](../base/README.md), plus one of:
 


### PR DESCRIPTION
The old link lead to a 404.