### PR TITLE
Fix Typo in distroless/cc/README.md

### DIFF
--- a/cc/README.md
+++ b/cc/README.md
@@ -1,4 +1,4 @@
-# Documentation for `gcr.io/distroless/cc`
+# Documentation for `ghcr.io/distroless/cc`
 
 ## Image Contents
 


### PR DESCRIPTION
There was the letter 'h' missing from 'ghcr.io...'