### PR TITLE
Make jexec and jspawnhelper executable

### DIFF
--- a/java/testdata/java21_debian12.yaml
+++ b/java/testdata/java21_debian12.yaml
@@ -25,6 +25,14 @@ fileExistenceTests:
   - name: no-javac
     path: "/usr/lib/jvm/temurin21_jre_amd64/bin/javac"
     shouldExist: false
+  - name: jexec-executable
+    path: "/usr/lib/jvm/temurin21_jre_amd64/lib/jexec"
+    shouldExist: true
+    isExecutableBy: "any"
+  - name: jspawnhelper-executable
+    path: "/usr/lib/jvm/temurin21_jre_amd64/lib/jspawnhelper"
+    shouldExist: true
+    isExecutableBy: "any"
 metadataTest:
   envVars:
     - key: 'JAVA_VERSION'

--- a/private/remote/temurin_archive.bzl
+++ b/private/remote/temurin_archive.bzl
@@ -11,16 +11,14 @@ pkg_files(
     srcs = glob(
         ["output/**/*"],
     ),
-    excludes = ["_bin_dir", "_cacerts"],
+    excludes = ["_executables", "_cacerts"],
     strip_prefix = "output",
 )
 
-# special rules for bin files to make them executable
+# special rules for bin files to make them executable and other executables
 pkg_files(
-    name = "_bin_dir",
-    srcs = glob(
-        ["output/bin/*"],
-    ),
+    name = "_executables",
+    srcs = glob(["output/bin/*"]) + ["output/lib/jexec", "output/lib/jspawnhelper"],
     attributes = pkg_attributes(
         mode = "0755",
         user = "root",
@@ -32,7 +30,7 @@ pkg_files(
 # everything that needs to go into the jvm install dir
 pkg_filegroup(
     name = "_jvm_dir",
-    srcs = ["_bin_dir", "_most_files"],
+    srcs = ["_executables", "_most_files"],
     prefix = "/usr/lib/jvm/{name}",
 )
 


### PR DESCRIPTION
In the future we should use a tar rule that preserves file permissions, this approach is a bit brittle

ref: https://github.com/GoogleContainerTools/distroless/issues/1405#issuecomment-1841898382