### PR TITLE
Update rust example

### DIFF
--- a/examples/rust/BUILD
+++ b/examples/rust/BUILD
@@ -12,7 +12,7 @@ package(default_visibility = ["//visibility:public"])
 rust_image(
     name = "rust_example",
     srcs = ["src/main.rs"],
-    base = "//cc:cc_root_amd64_debian11",
+    base = "//cc:cc_root_amd64_debian12",
     tags = [
         "amd64",
         "manual",

--- a/examples/rust/Dockerfile
+++ b/examples/rust/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:1.41.0 as build-env
+FROM rust:1 as build-env
 WORKDIR /app
 COPY . /app
 RUN cargo build --release
 
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc-debian12
 COPY --from=build-env /app/target/release/hello-world-distroless /
 CMD ["./hello-world-distroless"]


### PR DESCRIPTION
Current rust builds want newer glibc only present in debian12, else CMD errors in runtime.

distroless/cc: README: Any other tags are considered deprecated and are no longer updated → use distroless/cc-debian12

build-env: lessen cargo pin to only major version. There is no practical need for it to be pinned to patch.