### PR TITLE
chore: upgrade rules_oci

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ load("@rules_oci//oci/private:tarball.bzl", "oci_tarball")
 oci_tarball(
     name = "local_build",
     image = "//base:static_root_amd64_debian17",
-    repotags = [],
+    repo_tags = [],
 )
 ```
 then build the tarball and load it into docker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Follow either of the two links above to access the appropriate CLA and instructi
 
 1. For building and loading images to your local Docker engine, you need to add a new rule for that image to the BUILD:
 ```
-load("@contrib_rules_oci//oci/private:tarball.bzl", "oci_tarball")
+load("@rules_oci//oci/private:tarball.bzl", "oci_tarball")
 
 oci_tarball(
     name = "local_build",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,17 +4,17 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # rules_oci setup
 http_archive(
-    name = "contrib_rules_oci",
-    sha256 = "d6bdc1767d326c67b4cbdc79abfed00c8a4ca14b92adea9faf3db4710d514596",
-    strip_prefix = "rules_oci-0.3.2",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v0.3.2/rules_oci-v0.3.2.tar.gz",
+    name = "rules_oci",
+    sha256 = "a3b6f4c0051938940ccf251a7bdcdf7ac5a93ae00e63ad107c9c6d3bfe20885b",
+    strip_prefix = "rules_oci-1.3.1",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.3.1/rules_oci-v1.3.1.tar.gz",
 )
 
-load("@contrib_rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 
 rules_oci_dependencies()
 
-load("@contrib_rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "LATEST_ZOT_VERSION", "oci_register_toolchains")
+load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "LATEST_ZOT_VERSION", "oci_register_toolchains")
 
 oci_register_toolchains(
     name = "oci",
@@ -22,9 +22,21 @@ oci_register_toolchains(
     zot_version = LATEST_ZOT_VERSION,
 )
 
-load("@contrib_rules_oci//cosign:repositories.bzl", "cosign_register_toolchains")
+load("@rules_oci//cosign:repositories.bzl", "cosign_register_toolchains")
 
 cosign_register_toolchains(name = "oci_cosign")
+
+# setup container_structure_test
+http_archive(
+    name = "container_structure_test",
+    sha256 = "2da13da4c4fec9d4627d4084b122be0f4d118bd02dfa52857ff118fde88e4faa",
+    strip_prefix = "container-structure-test-1.16.0",
+    urls = ["https://github.com/GoogleContainerTools/container-structure-test/archive/v1.16.0.zip"],
+)
+
+load("@container_structure_test//:repositories.bzl", "container_structure_test_register_toolchain")
+
+container_structure_test_register_toolchain(name = "cst")
 
 # platforms
 http_archive(

--- a/base/base.bzl
+++ b/base/base.bzl
@@ -110,7 +110,6 @@ def distro_components(distro):
 
             oci_image(
                 name = "base_nossl_" + user + "_" + arch + "_" + distro,
-                architecture = arch,
                 base = ":static_" + user + "_" + arch + "_" + distro,
                 tars = [
                     deb_pkg(arch, distro, "libc6"),

--- a/base/base.bzl
+++ b/base/base.bzl
@@ -1,9 +1,11 @@
-# defines a function to replicate the container images for different distributions
-load("//cacerts:cacerts.bzl", "cacerts")
-load("//:checksums.bzl", "ARCHITECTURES", "VARIANTS")
+"defines a function to replicate the container images for different distributions"
+
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//:checksums.bzl", "ARCHITECTURES", "VARIANTS")
+load("//cacerts:cacerts.bzl", "cacerts")
 
 NONROOT = 65532
 
@@ -193,9 +195,9 @@ def distro_components(distro):
             visibility = ["//visibility:private"],
         )
 
-        structure_test(
+        container_structure_test(
             name = "static_" + arch + "_" + distro + "_test",
-            config = ["testdata/static.yaml"],
+            configs = ["testdata/static.yaml"],
             image = ":check_certs_image_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
@@ -204,9 +206,9 @@ def distro_components(distro):
         # Check that we can invoke openssl in the base image to check certificates (only debian11).
         ##########################################################################################
         if distro == "debian11":
-            structure_test(
+            container_structure_test(
                 name = "openssl_" + arch + "_" + distro + "_test",
-                config = ["testdata/certs.yaml"],
+                configs = ["testdata/certs.yaml"],
                 image = ":base_root_" + arch + "_" + distro,
                 tags = ["manual", arch],
             )
@@ -214,16 +216,16 @@ def distro_components(distro):
         ##########################################################################################
         # Check for common base files.
         ##########################################################################################
-        structure_test(
+        container_structure_test(
             name = "base_" + arch + "_" + distro + "_test",
-            config = ["testdata/base.yaml"],
+            configs = ["testdata/base.yaml"],
             image = ":base_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
 
-        structure_test(
+        container_structure_test(
             name = "base_nossl_" + arch + "_" + distro + "_test",
-            config = ["testdata/base.yaml"],
+            configs = ["testdata/base.yaml"],
             image = ":base_nossl_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
@@ -231,23 +233,23 @@ def distro_components(distro):
         ##########################################################################################
         # Check for busybox
         ##########################################################################################
-        structure_test(
+        container_structure_test(
             name = "debug_" + arch + "_" + distro + "_test",
-            config = ["testdata/debug.yaml"],
+            configs = ["testdata/debug.yaml"],
             image = ":debug_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
 
-        structure_test(
+        container_structure_test(
             name = "base_nossl_debug_" + arch + "_" + distro + "_test",
-            config = ["testdata/debug.yaml"],
+            configs = ["testdata/debug.yaml"],
             image = ":base_nossl_debug_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
 
-        structure_test(
+        container_structure_test(
             name = "static_debug_" + arch + "_" + distro + "_test",
-            config = ["testdata/debug.yaml"],
+            configs = ["testdata/debug.yaml"],
             image = ":static_debug_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
@@ -255,37 +257,37 @@ def distro_components(distro):
         ##########################################################################################
         # Check the /etc/os-release contents.
         ##########################################################################################
-        structure_test(
+        container_structure_test(
             name = "base_release_" + arch + "_" + distro + "_test",
-            config = ["testdata/" + distro + ".yaml"],
+            configs = ["testdata/" + distro + ".yaml"],
             image = ":base_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
 
-        structure_test(
+        container_structure_test(
             name = "base_nossl_release_" + arch + "_" + distro + "_test",
-            config = ["testdata/" + distro + ".yaml"],
+            configs = ["testdata/" + distro + ".yaml"],
             image = ":base_nossl_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
 
-        structure_test(
+        container_structure_test(
             name = "debug_release_" + arch + "_" + distro + "_test",
-            config = ["testdata/" + distro + ".yaml"],
+            configs = ["testdata/" + distro + ".yaml"],
             image = ":debug_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
 
-        structure_test(
+        container_structure_test(
             name = "static_release_" + arch + "_" + distro + "_test",
-            config = ["testdata/" + distro + ".yaml"],
+            configs = ["testdata/" + distro + ".yaml"],
             image = ":static_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )
 
-        structure_test(
+        container_structure_test(
             name = "static_debug_release_" + arch + "_" + distro + "_test",
-            config = ["testdata/" + distro + ".yaml"],
+            configs = ["testdata/" + distro + ".yaml"],
             image = ":static_debug_root_" + arch + "_" + distro,
             tags = ["manual", arch],
         )

--- a/cc/BUILD
+++ b/cc/BUILD
@@ -1,4 +1,4 @@
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("//base:distro.bzl", "DISTROS")
 load("//base:base.bzl", "deb_pkg")
 load("//:checksums.bzl", "ARCHITECTURES")

--- a/examples/cc/BUILD
+++ b/examples/cc/BUILD
@@ -1,8 +1,8 @@
 # Public notice: this file is for internal documentation, testing, and
 # reference only. Note that repo maintainers can freely change any part of the
 # repository code at any time.
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//base:distro.bzl", "DISTROS")
-load("@contrib_rules_oci//oci:defs.bzl", "structure_test")
 load("//private/oci:defs.bzl", "cc_image")
 
 package(default_visibility = ["//visibility:public"])
@@ -19,10 +19,10 @@ package(default_visibility = ["//visibility:public"])
     base = "//cc:cc_root_amd64_" + distro,
 ) for distro in DISTROS]
 
-[structure_test(
+[container_structure_test(
     name = "hello_" + distro + "_test",
     size = "small",
-    config = ["testdata/hello_" + distro + ".yaml"],
+    configs = ["testdata/hello_" + distro + ".yaml"],
     image = ":hello_" + distro,
     tags = [
         "amd64",
@@ -30,10 +30,10 @@ package(default_visibility = ["//visibility:public"])
     ],
 ) for distro in DISTROS]
 
-[structure_test(
+[container_structure_test(
     name = "hello_cc_" + distro + "_test",
     size = "small",
-    config = ["testdata/hello_cc_" + distro + ".yaml"],
+    configs = ["testdata/hello_cc_" + distro + ".yaml"],
     image = ":hello_cc_" + distro,
     tags = [
         "amd64",

--- a/examples/go/BUILD
+++ b/examples/go/BUILD
@@ -1,7 +1,7 @@
 # Public notice: this file is for internal documentation, testing, and
 # reference only. Note that repo maintainers can freely change any part of the
 # repository code at any time.
-load("@contrib_rules_oci//oci:defs.bzl", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_tarball")
 load("//private/oci:defs.bzl", "go_image")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/go/BUILD
+++ b/examples/go/BUILD
@@ -19,5 +19,5 @@ go_image(
 oci_tarball(
     name = "tarball",
     image = ":go_example",
-    repotags = ["distroless/examples/go:latest"],
+    repo_tags = ["distroless/examples/go:latest"],
 )

--- a/examples/java/BUILD
+++ b/examples/java/BUILD
@@ -1,9 +1,8 @@
 # Public notice: this file is for internal documentation, testing, and
 # reference only. Note that repo maintainers can freely change any part of the
 # repository code at any time.
-load("@contrib_rules_oci//oci:defs.bzl", "structure_test")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//private/oci:defs.bzl", "java_image")
-load("//base:distro.bzl", DISTROS = "LANGUAGE_DISTROS")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -28,10 +27,10 @@ JAVA_VERSIONS_PER_DISTRO = [
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "hello_java" + java_version + "_" + user + "_" + distro + "_test",
         size = "small",
-        config = ["testdata/hello_" + user + "_" + distro + ".yaml"],
+        configs = ["testdata/hello_" + user + "_" + distro + ".yaml"],
         image = ":hello_java" + java_version + "_" + user + "_" + distro,
         tags = [
             "amd64",

--- a/examples/nodejs/BUILD
+++ b/examples/nodejs/BUILD
@@ -1,10 +1,11 @@
 # Public notice: this file is for internal documentation, testing, and
 # reference only. Note that repo maintainers can freely change any part of the
 # repository code at any time.
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "structure_test")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("//base:distro.bzl", "DISTROS")
 load("//:checksums.bzl", ARCHITECTURES = "BASE_ARCHITECTURES")
+load("//base:distro.bzl", "DISTROS")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -56,9 +57,9 @@ pkg_tar(
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "hello_" + user + "_" + arch + "_" + distro + "_test",
-        config = ["testdata/hello.yaml"],
+        configs = ["testdata/hello.yaml"],
         image = ":hello_" + user + "_" + arch + "_" + distro,
         tags = [
             arch,

--- a/examples/nonroot/BUILD
+++ b/examples/nonroot/BUILD
@@ -1,10 +1,11 @@
 # Public notice: this file is for internal documentation, testing, and
 # reference only. Note that repo maintainers can freely change any part of the
 # repository code at any time.
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "structure_test")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//base:distro.bzl", "DISTROS")
 
 # Create a passwd file with a nonroot user and uid.
@@ -61,9 +62,9 @@ pkg_tar(
 ) for distro in DISTROS]
 
 # Test to verify this works :)
-[structure_test(
+[container_structure_test(
     name = "check_user_" + distro + "_test",
-    config = ["testdata/user.yaml"],
+    configs = ["testdata/user.yaml"],
     image = ":check_user_image_" + distro,
     tags = [
         "amd64",

--- a/examples/python3/BUILD
+++ b/examples/python3/BUILD
@@ -42,7 +42,7 @@ oci_image(
     oci_tarball(
         name = "tarball_" + distro,
         image = ":hello_" + distro,
-        repotags = ["distroless/examples/py:latest"],
+        repo_tags = ["distroless/examples/py:latest"],
     )
     for distro in DISTROS
 ]

--- a/examples/python3/BUILD
+++ b/examples/python3/BUILD
@@ -1,7 +1,7 @@
 # Public notice: this file is for internal documentation, testing, and
 # reference only. Note that repo maintainers can freely change any part of the
 # repository code at any time.
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//base:distro.bzl", "DISTROS")
 

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -135,7 +135,7 @@ DISTRO_VERSION = {
     oci_tarball(
         name = "python3_root_" + arch + "_debian11_tarball",
         image = ":python3_root_" + arch + "_debian11",
-        repotags = ["distroless/gen/python3_root_%s_debian11_tarball:gen" % arch],
+        repo_tags = ["distroless/gen/python3_root_%s_debian11_tarball:gen" % arch],
         tags = [
             "manual",
             arch,

--- a/experimental/python3/BUILD
+++ b/experimental/python3/BUILD
@@ -1,8 +1,9 @@
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_tarball", "structure_test")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//:checksums.bzl", ARCHITECTURES = "BASE_ARCHITECTURES")
-load("//base:distro.bzl", DISTROS = "LANGUAGE_DISTROS")
 load("//base:base.bzl", "NONROOT", "deb_pkg")
+load("//base:distro.bzl", DISTROS = "LANGUAGE_DISTROS")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -195,10 +196,10 @@ mv tmp/ld.so.cache $(OUTS)
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "python3_" + user + "_" + arch + "_" + distro + "_test",
         size = "medium",
-        config = ["testdata/python3.yaml"],
+        configs = ["testdata/python3.yaml"],
         image = ":python3_" + user + "_" + arch + "_" + distro,
         tags = [
             "manual",
@@ -215,10 +216,10 @@ mv tmp/ld.so.cache $(OUTS)
 
 # tests for version-specific things
 [
-    structure_test(
+    container_structure_test(
         name = "version_specific_" + user + "_" + arch + "_" + distro + "_test",
         size = "medium",
-        config = ["testdata/" + distro + ".yaml"],
+        configs = ["testdata/" + distro + ".yaml"],
         image = ":python3_" + user + "_" + arch + "_" + distro,
         tags = [
             "manual",

--- a/java/BUILD
+++ b/java/BUILD
@@ -1,12 +1,13 @@
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "structure_test")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("//private/oci:defs.bzl", "java_image")
+load("//:debian_versions.bzl", DEBIAN_VERSIONS = "DEBIAN_PACKAGE_VERSIONS")
+load("//:java_archives.bzl", "JAVA_RELEASE_VERSIONS")
 load("//base:base.bzl", "deb_pkg")
 load("//base:distro.bzl", "DISTROS")
 load("//cacerts:java.bzl", "cacerts_java")
 load("//java:jre_ver.bzl", "jre_ver")
-load("//:debian_versions.bzl", DEBIAN_VERSIONS = "DEBIAN_PACKAGE_VERSIONS")
-load("//:java_archives.bzl", "JAVA_RELEASE_VERSIONS")
+load("//private/oci:defs.bzl", "java_image")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -323,9 +324,9 @@ DISTRO_SPECIFIC_LIBRARIES = {
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "java_base" + mode + "_" + user + "_" + arch + "_" + distro + "_test",
-        config = ["testdata/java_base" + mode + ".yaml"],
+        configs = ["testdata/java_base" + mode + ".yaml"],
         image = ":java_base" + mode + "_" + user + "_" + arch + "_" + distro,
         tags = [
             arch,
@@ -342,9 +343,9 @@ DISTRO_SPECIFIC_LIBRARIES = {
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "java" + java_version + "_" + user + "_" + arch + "_" + distro + "_test",
-        config = ["testdata/java" + java_version + "_" + distro + ".yaml"],
+        configs = ["testdata/java" + java_version + "_" + distro + ".yaml"],
         image = ":java" + java_version + "_" + user + "_" + arch + "_" + distro,
         tags = [
             arch,
@@ -357,9 +358,9 @@ DISTRO_SPECIFIC_LIBRARIES = {
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "java" + java_version + "_debug_" + user + "_" + arch + "_" + distro + "_test",
-        config = ["testdata/java" + java_version + "_debug" + "_" + distro + ".yaml"],
+        configs = ["testdata/java" + java_version + "_debug" + "_" + distro + ".yaml"],
         image = ":java" + java_version + "_debug_" + user + "_" + arch + "_" + distro,
         tags = [
             arch,
@@ -393,9 +394,9 @@ RULE_NAMES = [
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "check_certs_" + rule_name + "_test",
-        config = ["testdata/java_certs.yaml"],
+        configs = ["testdata/java_certs.yaml"],
         image = ":check_certs_" + rule_name,
         tags = [
             "amd64",
@@ -416,9 +417,9 @@ RULE_NAMES = [
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "check_encoding_" + rule_name + "_test",
-        config = ["testdata/java_encoding.yaml"],
+        configs = ["testdata/java_encoding.yaml"],
         image = ":check_encoding_" + rule_name,
         tags = [
             "amd64",
@@ -439,9 +440,9 @@ RULE_NAMES = [
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "check_libharfbuzz_" + rule_name + "_test",
-        config = ["testdata/java_libharfbuzz.yaml"],
+        configs = ["testdata/java_libharfbuzz.yaml"],
         image = ":check_libharfbuzz_" + rule_name,
         tags = [
             "amd64",

--- a/java/BUILD
+++ b/java/BUILD
@@ -227,7 +227,6 @@ DISTRO_SPECIFIC_LIBRARIES = {
 [
     oci_image(
         name = "java" + java_version + "_debug_" + user + "_" + arch + "_" + distro,
-        architecture = arch,
         base = ":java_base_debug_" + user + "_" + arch + "_" + distro,
         # We expect users to use:
         # cmd = ["/path/to/deploy.jar", "--option1", ...]
@@ -303,7 +302,6 @@ DISTRO_SPECIFIC_LIBRARIES = {
 [
     oci_image(
         name = "java" + java_version + "_debug_" + user + "_" + arch + "_" + distro,
-        architecture = arch,
         base = ":java_build_base_debug_" + user + "_" + arch + "_" + distro,
         # We expect users to use:
         # cmd = ["/path/to/deploy.jar", "--option1", ...]

--- a/java/jetty/BUILD
+++ b/java/jetty/BUILD
@@ -1,5 +1,6 @@
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 load("//base:distro.bzl", DISTROS = "LANGUAGE_DISTROS")
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "structure_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -15,9 +16,9 @@ package(default_visibility = ["//visibility:public"])
     ("jetty_java11_debug_debian11", "//java:java11_debug_root_amd64_debian11"),
 ]]
 
-[structure_test(
+[container_structure_test(
     name = "jetty_java11_" + distro + "_test",
-    config = ["testdata/java11.yaml"],
+    configs = ["testdata/java11.yaml"],
     image = ":jetty_java11_" + distro,
     tags = [
         "amd64",
@@ -25,9 +26,9 @@ package(default_visibility = ["//visibility:public"])
     ],
 ) for distro in DISTROS]
 
-[structure_test(
+[container_structure_test(
     name = "jetty_java11_debug_" + distro + "_test",
-    config = ["testdata/java11_debug.yaml"],
+    configs = ["testdata/java11_debug.yaml"],
     image = ":jetty_java11_debug_" + distro,
     tags = [
         "amd64",

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -1,7 +1,8 @@
-load("//base:distro.bzl", "DISTROS")
-load("//:checksums.bzl", "ARCHITECTURES")
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "structure_test")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//:checksums.bzl", "ARCHITECTURES")
+load("//base:distro.bzl", "DISTROS")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -48,9 +49,9 @@ USER = [
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "nodejs" + major_version + ("" if (not mode) else mode) + "_" + user + "_" + arch + "_" + distro + "_test",
-        config = [
+        configs = [
             "testdata/nodejs" + major_version + ".yaml",
             "testdata/check_npm.yaml",
         ],
@@ -88,9 +89,9 @@ pkg_tar(
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "check_certificate_nodejs" + major_version + ("" if (not mode) else mode) + "_" + user + "_" + arch + "_" + distro + "_test",
-        config = ["testdata/check_certificate.yaml"],
+        configs = ["testdata/check_certificate.yaml"],
         image = "check_certificate_nodejs" + major_version + ("" if (not mode) else mode) + "_" + user + "_" + arch + "_" + distro,
         tags = [
             arch,

--- a/private/oci/cc_image.bzl
+++ b/private/oci/cc_image.bzl
@@ -1,4 +1,4 @@
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 def cc_image(name, srcs, base):

--- a/private/oci/go_image.bzl
+++ b/private/oci/go_image.bzl
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 
 def go_image(name, srcs, base, arch = "amd64", os = "linux"):
     go_binary(

--- a/private/oci/java_image.bzl
+++ b/private/oci/java_image.bzl
@@ -1,4 +1,4 @@
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 def java_image(name, srcs, main_class, base):

--- a/private/oci/rust_image.bzl
+++ b/private/oci/rust_image.bzl
@@ -1,4 +1,4 @@
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 

--- a/private/oci/sign_and_push.bzl
+++ b/private/oci/sign_and_push.bzl
@@ -1,5 +1,5 @@
-load("@contrib_rules_oci//oci:defs.bzl", "oci_push")
-load("@contrib_rules_oci//cosign:defs.bzl", "cosign_attest", "cosign_sign")
+load("@rules_oci//oci:defs.bzl", "oci_push")
+load("@rules_oci//cosign:defs.bzl", "cosign_attest", "cosign_sign")
 load("//private/pkg:oci_image_spdx.bzl", "oci_image_spdx")
 
 PUSH_AND_SIGN_CMD = """\

--- a/private/pkg/test/oci_image/BUILD.bazel
+++ b/private/pkg/test/oci_image/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("//private/pkg:oci_image_spdx.bzl", "oci_image_spdx")
 load("//base:base.bzl", "deb_pkg")

--- a/python3/BUILD
+++ b/python3/BUILD
@@ -1,7 +1,8 @@
-load("@contrib_rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_tarball", "structure_test")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("//base:base.bzl", "deb_pkg")
 load("//:checksums.bzl", ARCHITECTURES = "BASE_ARCHITECTURES")
+load("//base:base.bzl", "deb_pkg")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -93,10 +94,10 @@ DISTRO_VERSION = {
 ]
 
 [
-    structure_test(
+    container_structure_test(
         name = "python3_" + user + "_" + arch + "_" + distro + "_test",
         size = "medium",
-        config = ["testdata/python3.yaml"],
+        configs = ["testdata/python3.yaml"],
         image = ":python3_" + user + "_" + arch + "_" + distro,
         tags = [
             "manual",
@@ -110,10 +111,10 @@ DISTRO_VERSION = {
 
 # tests for version-specific things
 [
-    structure_test(
+    container_structure_test(
         name = "version_specific_" + user + "_" + arch + "_" + distro + "_test",
         size = "medium",
-        config = ["testdata/" + distro + ".yaml"],
+        configs = ["testdata/" + distro + ".yaml"],
         image = ":python3_" + user + "_" + arch + "_" + distro,
         tags = [
             "manual",


### PR DESCRIPTION
Upgrading rules_oci to get https://github.com/bazel-contrib/rules_oci/pull/335 into distroless. 

Changes

- reorder some of load statements
- bring in container_structure_test as rules_oci no longer provides it builtin
- upgrade rules_oci 