### PR TITLE
chore: update java 21 patch version

### DIFF
--- a/java/testdata/java21_debian12.yaml
+++ b/java/testdata/java21_debian12.yaml
@@ -3,11 +3,11 @@ commandTests:
   - name: java
     command: "/usr/lib/jvm/temurin21_jre_amd64/bin/java"
     args: ["-version"]
-    expectedError: ['openjdk version "21.0.1"']
+    expectedError: ['openjdk version "21.0.2"']
   - name: java-symlink
     command: "/usr/bin/java"
     args: ["-version"]
-    expectedError: ['openjdk version "21.0.1"']
+    expectedError: ['openjdk version "21.0.2"']
 fileExistenceTests:
   - name: certs
     path: "/etc/ssl/certs/java/cacerts"
@@ -36,4 +36,4 @@ fileExistenceTests:
 metadataTest:
   envVars:
     - key: 'JAVA_VERSION'
-      value: '21.0.1'
+      value: '21.0.2'

--- a/java/testdata/java21_debug_debian12.yaml
+++ b/java/testdata/java21_debug_debian12.yaml
@@ -3,15 +3,15 @@ commandTests:
   - name: java
     command: "/usr/lib/jvm/temurin21_jdk_amd64/bin/java"
     args: ["-version"]
-    expectedError: ['openjdk version "21.0.1"']
+    expectedError: ['openjdk version "21.0.2"']
   - name: java-symlink
     command: "/usr/bin/java"
     args: ["-version"]
-    expectedError: ['openjdk version "21.0.1"']
+    expectedError: ['openjdk version "21.0.2"']
   - name: javac
     command: "/usr/lib/jvm/temurin21_jdk_amd64/bin/javac"
     args: ["-version"]
-    expectedOutput: ['javac 21.0.1']
+    expectedOutput: ['javac 21.0.2']
 fileExistenceTests:
   - name: certs
     path: "/etc/ssl/certs/java/cacerts"
@@ -29,4 +29,4 @@ fileExistenceTests:
 metadataTest:
   envVars:
    - key: 'JAVA_VERSION'
-     value: '21.0.1'
+     value: '21.0.2'

--- a/java_archives.bzl
+++ b/java_archives.bzl
@@ -3,71 +3,71 @@
 load("//private/remote:temurin_archive.bzl", "temurin_archive")
 
 JAVA_RELEASE_VERSIONS = {
-    "temurin21_jre_amd64": "21.0.1",
-    "temurin21_jdk_amd64": "21.0.1",
-    "temurin21_jre_arm64": "21.0.1",
-    "temurin21_jdk_arm64": "21.0.1",
-    "temurin21_jre_ppc64le": "21.0.1",
-    "temurin21_jdk_ppc64le": "21.0.1",
+    "temurin21_jre_amd64": "21.0.2",
+    "temurin21_jdk_amd64": "21.0.2",
+    "temurin21_jre_arm64": "21.0.2",
+    "temurin21_jdk_arm64": "21.0.2",
+    "temurin21_jre_ppc64le": "21.0.2",
+    "temurin21_jdk_ppc64le": "21.0.2",
 }
 
 def repositories():
     temurin_archive(
         name = "temurin21_jre_amd64",
-        sha256 = "277f4084bee875f127a978253cfbaad09c08df597feaf5ccc82d2206962279a3",
-        strip_prefix = "jdk-21.0.1+12-jre",
-        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1+12/OpenJDK21U-jre_x64_linux_hotspot_21.0.1_12.tar.gz"],
-        version = "21.0.1+12",
+        sha256 = "51141204fe01a9f9dd74eab621d5eca7511eac67315c9975dbde5f2625bdca55",
+        strip_prefix = "jdk-21.0.2+13-jre",
+        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_x64_linux_hotspot_21.0.2_13.tar.gz"],
+        version = "21.0.2+13",
         architecture = "amd64",
         control = "//java:control",
     )
 
     temurin_archive(
         name = "temurin21_jdk_amd64",
-        sha256 = "1a6fa8abda4c5caed915cfbeeb176e7fbd12eb6b222f26e290ee45808b529aa1",
-        strip_prefix = "jdk-21.0.1+12",
-        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1+12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz"],
-        version = "21.0.1+12",
+        sha256 = "454bebb2c9fe48d981341461ffb6bf1017c7b7c6e15c6b0c29b959194ba3aaa5",
+        strip_prefix = "jdk-21.0.2+13",
+        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_x64_linux_hotspot_21.0.2_13.tar.gz"],
+        version = "21.0.2+13",
         architecture = "amd64",
         control = "//java:control",
     )
 
     temurin_archive(
         name = "temurin21_jre_arm64",
-        sha256 = "4582c4cc0c6d498ba7a23fdb0a5179c9d9c0d7a26f2ee8610468d5c2954fcf2f",
-        strip_prefix = "jdk-21.0.1+12-jre",
-        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jre_aarch64_linux_hotspot_21.0.1_12.tar.gz"],
-        version = "21.0.1+12",
+        sha256 = "64c78854184c92a4da5cda571c8e357043bfaf03a03434eef58550cc3410d8a4",
+        strip_prefix = "jdk-21.0.2+13-jre",
+        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_aarch64_linux_hotspot_21.0.2_13.tar.gz"],
+        version = "21.0.2+13",
         architecture = "arm64",
         control = "//java:control",
     )
 
     temurin_archive(
         name = "temurin21_jdk_arm64",
-        sha256 = "e184dc29a6712c1f78754ab36fb48866583665fa345324f1a79e569c064f95e9",
-        strip_prefix = "jdk-21.0.1+12",
-        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz"],
-        version = "21.0.1+12",
+        sha256 = "3ce6a2b357e2ef45fd6b53d6587aa05bfec7771e7fb982f2c964f6b771b7526a",
+        strip_prefix = "jdk-21.0.2+13",
+        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.2_13.tar.gz"],
+        version = "21.0.2+13",
         architecture = "arm64",
         control = "//java:control",
     )
 
     temurin_archive(
         name = "temurin21_jre_ppc64le",
-        sha256 = "05cc9b7bfbe246c27d307783b3d5095797be747184b168018ae3f7cc55608db2",
-        strip_prefix = "jdk-21.0.1+12-jre",
-        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jre_ppc64le_linux_hotspot_21.0.1_12.tar.gz"],
-        version = "21.0.1+12",
+        sha256 = "caaf48e50787b80b810dc08ee91bd4ffe0d0696bd14906a92f05bf8c14aabb22",
+        strip_prefix = "jdk-21.0.2+13-jre",
+        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_ppc64le_linux_hotspot_21.0.2_13.tar.gz"],
+        version = "21.0.2+13",
         architecture = "ppc64le",
         control = "//java:control",
     )
 
     temurin_archive(
         name = "temurin21_jdk_ppc64le",
-        sha256 = "9574828ef3d735a25404ced82e09bf20e1614f7d6403956002de9cfbfcb8638f",
-        strip_prefix = "jdk-21.0.1+12",
-        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.1_12.tar.gz"],
-        version = "21.0.1+12",
+        sha256 = "d08de863499d8851811c893e8915828f2cd8eb67ed9e29432a6b4e222d80a12f",
+        strip_prefix = "jdk-21.0.2+13",
+        urls = ["https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.2_13.tar.gz"],
+        version = "21.0.2+13",
         architecture = "ppc64le",
         control = "//java:control",
     )


### PR DESCRIPTION
In our organisations we're getting warnings about CVEs in Java 21.0.1, f.ex https://nvd.nist.gov/vuln/detail/CVE-2024-20952. These should be fixed in 21.0.2.