### PR TITLE
fix: make busybox reproducible

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,22 @@ workspace(name = "distroless")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# rules_distroless setup
+http_archive(
+    name = "rules_distroless",
+    sha256 = "4b6d6a4bd03431f4f680ff5f6feea0b8ccf52c0296a12818d2c9595392e45543",
+    strip_prefix = "rules_distroless-0.2.0",
+    url = "https://github.com/GoogleContainerTools/rules_distroless/releases/download/v0.2.0/rules_distroless-v0.2.0.tar.gz",
+)
+
+load("@rules_distroless//distroless:dependencies.bzl", "distroless_dependencies")
+
+distroless_dependencies()
+
+load("@rules_distroless//distroless:toolchains.bzl", "distroless_register_toolchains")
+
+distroless_register_toolchains()
+
 # rules_oci setup
 http_archive(
     name = "rules_oci",

--- a/base/base.bzl
+++ b/base/base.bzl
@@ -144,7 +144,7 @@ def distro_components(distro):
                 base = ":base_" + user + "_" + arch + "_" + distro,
                 entrypoint = ["/busybox/sh"],
                 env = {"PATH": "$PATH:/busybox"},
-                tars = ["//experimental/busybox:busybox_" + arch + ".tar"],
+                tars = ["//experimental/busybox:busybox_" + arch],
             )
 
             # A base_nossl debug image with busybox available.
@@ -153,7 +153,7 @@ def distro_components(distro):
                 base = ":base_nossl_" + user + "_" + arch + "_" + distro,
                 entrypoint = ["/busybox/sh"],
                 env = {"PATH": "$PATH:/busybox"},
-                tars = ["//experimental/busybox:busybox_" + arch + ".tar"],
+                tars = ["//experimental/busybox:busybox_" + arch],
             )
 
             # A static debug image with busybox available.
@@ -162,7 +162,7 @@ def distro_components(distro):
                 base = ":static_" + user + "_" + arch + "_" + distro,
                 entrypoint = ["/busybox/sh"],
                 env = {"PATH": "$PATH:/busybox"},
-                tars = ["//experimental/busybox:busybox_" + arch + ".tar"],
+                tars = ["//experimental/busybox:busybox_" + arch],
             )
 
         ##########################################################################################

--- a/busybox_archives.bzl
+++ b/busybox_archives.bzl
@@ -1,17 +1,21 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+"repositories for busybox"
 
-# For the debug image
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("//experimental/busybox:commands.bzl", "BUSYBOX_ARCHIVE_BUILD")
+
 def repositories():
+    "For the debug image"
+
     # To update amd64 busybox binary (#1014)
     # Get the latest commit hash from dist-amd64 branch of docker-library repo. You can also view it
     # at https://github.com/docker-library/official-images/blob/master/library/busybox
     # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/latest/musl/busybox.tar.xz
     # Update the sha256 value. Since github api doesn't give sha256 value, it can be obtained using sha256sum command.
-    http_file(
+    http_archive(
         name = "busybox_amd64",
-        executable = True,
         sha256 = "77b216d55c6895ddb04a90f3025b5ce2480140da779fe3dca91303b135a1fefe",
         urls = ["https://github.com/docker-library/busybox/raw/09ee80aedec1d8c604f104e8bec41ed19274620a/latest/musl/busybox.tar.xz"],
+        build_file_content = BUSYBOX_ARCHIVE_BUILD,
     )
 
     http_file(
@@ -26,11 +30,11 @@ def repositories():
     # at https://github.com/docker-library/official-images/blob/master/library/busybox
     # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/latest/musl/busybox.tar.xz
     # Update the sha256 value. Since github api doesn't give sha256 value, it can be obtained using sha256sum command.
-    http_file(
+    http_archive(
         name = "busybox_arm64",
-        executable = True,
         sha256 = "1d0610f348ae3f95897a967fae429b0a0c712b252ca63e1547a89bf13a1a82c7",
         urls = ["https://github.com/docker-library/busybox/raw/e5e22cb0710fe54da4beaa6a72c1bd56b8fc9c54/latest/musl/busybox.tar.xz"],
+        build_file_content = BUSYBOX_ARCHIVE_BUILD,
     )
 
     http_file(
@@ -45,9 +49,9 @@ def repositories():
     # at https://github.com/docker-library/official-images/blob/master/library/busybox
     # Substitute it in the link: https://github.com/docker-library/busybox/raw/<latest-commit-hash>/latest/musl/busybox.tar.xz
     # Update the sha256 value. Since github api doesn't give sha256 value, it can be obtained using sha256sum command.
-    http_file(
+    http_archive(
         name = "busybox_ppc64le",
-        executable = True,
         sha256 = "2d898cab234190697e5df74c537dd86955e9f61725d6c86d97b97c3d58aed9ca",
         urls = ["https://github.com/docker-library/busybox/raw/aa059e43d48801abcb012dfa965a432fa12c385d/latest/musl/busybox.tar.xz"],
+        build_file_content = BUSYBOX_ARCHIVE_BUILD,
     )

--- a/experimental/busybox/BUILD
+++ b/experimental/busybox/BUILD
@@ -1,21 +1,21 @@
-package(default_visibility = ["//base:__subpackages__"])
-
 load("//:checksums.bzl", "ARCHITECTURES")
-load(":commands.bzl", "BUSYBOX_COMMANDS")
+load(":commands.bzl", "busybox_layer")
+
+package(default_visibility = ["//base:__subpackages__"])
 
 # This works for all architectures because it is just files.
 # Ppc64le/Arm64/Amd64 needs special case as there is no direct working binary file available.
-[genrule(
-    name = "busybox_" + arch + "_tar",
-    srcs = ["@busybox_" + arch + "//file"],
-    outs = ["busybox_" + arch + ".tar"],
-    cmd = "mkdir busybox; cp $(<) busybox/busybox; cd busybox; \
-           if [[ $(<) == *ppc64le* || $(<) == *arm64* || $(<) == *amd64* ]]; then \
-             tar -xf busybox ./bin && mv -f ./bin/busybox . && rm -rf ./bin; \
-           fi; \
-           for cmd in %s; do \
-             ln -s busybox $$cmd; \
-           done; \
-           cd ..; \
-           tar -cf $@ busybox" % " ".join(BUSYBOX_COMMANDS),
-) for arch in ARCHITECTURES]
+SPECIAL_CASE_ARCH = [
+    "ppc64le",
+    "arm64",
+    "amd64",
+]
+
+[
+    busybox_layer(
+        name = "busybox_" + arch,
+        busybox = "@busybox_" + arch + "//:file" if arch in SPECIAL_CASE_ARCH else "@busybox_" + arch + "//file",
+        compress = "gzip",
+    )
+    for arch in ARCHITECTURES
+]

--- a/experimental/busybox/commands.bzl
+++ b/experimental/busybox/commands.bzl
@@ -1,3 +1,5 @@
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+
 BUSYBOX_COMMANDS = [
     "[",
     "[[",
@@ -381,3 +383,24 @@ BUSYBOX_COMMANDS = [
     "zcat",
     "zcip",
 ]
+
+BUSYBOX_ARCHIVE_BUILD = """\
+filegroup(
+    name = "file",
+    srcs = ["bin/busybox"],
+    visibility = ["//visibility:public"]
+)
+"""
+
+def busybox_layer(busybox, **kwargs):
+    tar(
+        srcs = [busybox],
+        mtree = [
+            "./busybox/ uid=0 gid=0 mode=0755 time=0.0 type=dir",
+            "./busybox/busybox uid=0 gid=0 mode=0755 time=0.0 type=file content=$(location {})".format(busybox),
+        ] + [
+            "./busybox/{cmd} uid=0 gid=0 mode=0755 time=0.0 type=link link=/busybox/busybox".format(cmd = cmd)
+            for cmd in BUSYBOX_COMMANDS
+        ],
+        **kwargs
+    )


### PR DESCRIPTION
With https://github.com/GoogleContainerTools/distroless/pull/1538 i have discovered that busybox archives are non-reproducible.  

Its uid/gid mtime and permissions are directly affected by Bazel and the Host. 

<img width="631" alt="Screenshot 2024-03-05 at 3 54 35 PM" src="https://github.com/GoogleContainerTools/distroless/assets/20563340/8659839a-3915-46fc-a150-2b176acdbdb6">
