### PR TITLE
perf: implement a fast path for diff

### DIFF
--- a/private/tools/diff.bash
+++ b/private/tools/diff.bash
@@ -198,6 +198,12 @@ function test_image() {
     echo ""
 
     bazel run $push_label -- --repository $repo_stage --tag $tag_stamped
+
+    if [[ "$(crane digest $repo_origin:$tag_stamped)" == "$(crane digest $repo_stage:$tag_stamped)" ]]; then
+        echo "👍 $repo_origin:$tag_stamped and $repo_stage:$tag_stamped have identical hash."
+        return 
+    fi
+   
     if ! diffoci diff --pull=always --all-platforms --semantic "$repo_origin:$tag_stamped" "$repo_stage:$tag_stamped"; then
         echo ""
         echo "      🔬 To reproduce: bazel run //private/tools:diff -- --only $image_label"


### PR DESCRIPTION
Not all PRs change every image, therefore it's wasteful to diff every image even if they have the same hash. This fast path check will return early if the images have identical hashes.