### PR TITLE
fix: use gnu date instead

### DIFF
--- a/knife
+++ b/knife
@@ -38,12 +38,12 @@ function find_latest_snapshot() {
     local type="$1"
     local current="$(date +%Y-%m-01)"
     local tmp=$(mktemp)
-    while [ true ]; do
+    for _ in 1 2; do
         local q=$(date -d "$current" +"year=%Y&month=%m")
         if curl -fs "https://snapshot-cloudflare.debian.org/archive/debian/?$q" | grep -ohE "([0-9]+T[0-9]+Z)" > $tmp; then
             break
         fi
-        echo "Could not find snapshot at $current"
+        echo "Could not find snapshot at $current, going back a month" >&2
         # go back 1 month
         current="$(date -d "$current -1 month" +%Y-%m-01)"
     done

--- a/knife
+++ b/knife
@@ -15,6 +15,13 @@ set -o pipefail -o errexit -o nounset
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ $(uname) == "Darwin" ]; then
+    echo "WARNING: You are on a macos, you need to run 'brew install coreutils' to install required packages."
+    echo ""
+    export PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"
+fi
+
+
 function cmd_lock() {
     echo "🚧 Querying for repos"
     echo ""
@@ -29,16 +36,16 @@ function cmd_lock() {
 
 function find_latest_snapshot() {
     local type="$1"
-    local current="$(date +%Y-%m)"
+    local current="$(date +%Y-%m-01)"
     local tmp=$(mktemp)
     while [ true ]; do
-        local q=$(date -jf "%Y-%m" "2024-03" +"year=%Y&month=%m")
+        local q=$(date -d "$current" +"year=%Y&month=%m")
         if curl -fs "https://snapshot-cloudflare.debian.org/archive/debian/?$q" | grep -ohE "([0-9]+T[0-9]+Z)" > $tmp; then
             break
         fi
         echo "Could not find snapshot at $current"
         # go back 1 month
-        current=$(date -v-1m -j -f "%Y-%m" "$current" +"%Y-%m")
+        current="$(date -d "$current -1 month" +%Y-%m-01)"
     done
     cat $tmp | grep -ohE "([0-9]+T[0-9]+Z)" | head -n1
 }
@@ -65,10 +72,11 @@ function cmd_update_snapshot() {
         echo $'\n'
         if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
             echo "Aborting..."
+            exit 0
         fi
     fi
 
-    for mpath in "./common/package/"*.yaml; do
+    for mpath in "./private/repos/deb/"*.yaml; do
         current=$(grep -oE "debian/([0-9]+T[0-9]+Z)" $mpath | cut -d/ -f2 | head -n1)
         current_security=$(grep -oE "debian-security/([0-9]+T[0-9]+Z)" $mpath | cut -d/ -f2 | head -n1)
 


### PR DESCRIPTION
This fixes a bug where date calls made from update-snapshots were assuming bsd date and gnu date is the same. 