### PR TITLE
April 10, 2024 Security Releases for 20.x and 18.x of nodejs

### DIFF
--- a/node_archives.bzl
+++ b/node_archives.bzl
@@ -9,100 +9,100 @@ def repositories():
 
     node_archive(
         name = "nodejs18_amd64",
-        sha256 = "d226c39c5546dca97567db8f8ca7f92fca6572d44f181b1f85af83eee5d6f9e1",
-        strip_prefix = "node-v18.20.1-linux-x64/",
-        urls = ["https://nodejs.org/dist/v18.20.1/node-v18.20.1-linux-x64.tar.gz"],
-        version = "18.20.1",
+        sha256 = "a222595d353a7d1e48994a7d9c25e61ab1b8a1b0ce0652029f5cf999978b2e49",
+        strip_prefix = "node-v18.20.2-linux-x64/",
+        urls = ["https://nodejs.org/dist/v18.20.2/node-v18.20.2-linux-x64.tar.gz"],
+        version = "18.20.2",
         architecture = "amd64",
         control = "//nodejs:control",
     )
 
     node_archive(
         name = "nodejs18_arm64",
-        sha256 = "52896372b3b151f639be7efa8662d68aaeb065cae2c15d61d14e2b73ada79597",
-        strip_prefix = "node-v18.20.1-linux-arm64/",
-        urls = ["https://nodejs.org/dist/v18.20.1/node-v18.20.1-linux-arm64.tar.gz"],
-        version = "18.20.1",
+        sha256 = "0b21ad5a11dd6c59a62eb34d1a0c2af28fe29187fa60da2c993b7cdf2a5a2f28",
+        strip_prefix = "node-v18.20.2-linux-arm64/",
+        urls = ["https://nodejs.org/dist/v18.20.2/node-v18.20.2-linux-arm64.tar.gz"],
+        version = "18.20.2",
         architecture = "arm64",
         control = "//nodejs:control",
     )
 
     node_archive(
         name = "nodejs18_arm",
-        sha256 = "b61392490e84cc6050967bbfc59cfd9ad6e737b6db9ef9d479b0d79c900aef64",
-        strip_prefix = "node-v18.20.1-linux-armv7l/",
-        urls = ["https://nodejs.org/dist/v18.20.1/node-v18.20.1-linux-armv7l.tar.gz"],
-        version = "18.20.1",
+        sha256 = "adc55a8a594882b72967b05a4e47b4911879eeb44477f9447e05c84d420797ac",
+        strip_prefix = "node-v18.20.2-linux-armv7l/",
+        urls = ["https://nodejs.org/dist/v18.20.2/node-v18.20.2-linux-armv7l.tar.gz"],
+        version = "18.20.2",
         architecture = "arm",
         control = "//nodejs:control",
     )
 
     node_archive(
         name = "nodejs18_ppc64le",
-        sha256 = "69e0c2d291c0838f01f157fc4713cc86c803396c6c25524397339946cf31a4cb",
-        strip_prefix = "node-v18.20.1-linux-ppc64le/",
-        urls = ["https://nodejs.org/dist/v18.20.1/node-v18.20.1-linux-ppc64le.tar.gz"],
-        version = "18.20.1",
+        sha256 = "40193c181756789bb53130d5c96cfacb2e90dff3a5ef196014d4df8d9cecd6ba",
+        strip_prefix = "node-v18.20.2-linux-ppc64le/",
+        urls = ["https://nodejs.org/dist/v18.20.2/node-v18.20.2-linux-ppc64le.tar.gz"],
+        version = "18.20.2",
         architecture = "ppc64le",
         control = "//nodejs:control",
     )
 
     node_archive(
         name = "nodejs18_s390x",
-        sha256 = "39793752b0ef9abe39ff942bbd3e442d71990f0592b3b0805252adb1b9c78e21",
-        strip_prefix = "node-v18.20.1-linux-s390x/",
-        urls = ["https://nodejs.org/dist/v18.20.1/node-v18.20.1-linux-s390x.tar.gz"],
-        version = "18.20.1",
+        sha256 = "3c56d6addf76802c5f4e28dfccf4919c1affdf7d47937b4df902250e72eeca89",
+        strip_prefix = "node-v18.20.2-linux-s390x/",
+        urls = ["https://nodejs.org/dist/v18.20.2/node-v18.20.2-linux-s390x.tar.gz"],
+        version = "18.20.2",
         architecture = "s390x",
         control = "//nodejs:control",
     )
 
     node_archive(
         name = "nodejs20_amd64",
-        sha256 = "da2f590a39717792dcf8c4bf6b9e4b269601e6ce3a3f150a3c4b379f7eea6d83",
-        strip_prefix = "node-v20.12.1-linux-x64/",
-        urls = ["https://nodejs.org/dist/v20.12.1/node-v20.12.1-linux-x64.tar.gz"],
-        version = "20.12.1",
+        sha256 = "f8f9b6877778ed2d5f920a5bd853f0f8a8be1c42f6d448c763a95625cbbb4b0d",
+        strip_prefix = "node-v20.12.2-linux-x64/",
+        urls = ["https://nodejs.org/dist/v20.12.2/node-v20.12.2-linux-x64.tar.gz"],
+        version = "20.12.2",
         architecture = "amd64",
         control = "//nodejs:control",
     )
 
     node_archive(
         name = "nodejs20_arm64",
-        sha256 = "6eb199eaa4f83a729242c69792a126cb58ca6a60d791dffd9cedb4cfd32b96c0",
-        strip_prefix = "node-v20.12.1-linux-arm64/",
-        urls = ["https://nodejs.org/dist/v20.12.1/node-v20.12.1-linux-arm64.tar.gz"],
-        version = "20.12.1",
+        sha256 = "2dc8ffa0da135bf493f881d2d38aac610772c801bb7b6208fcc5de9350f119f7",
+        strip_prefix = "node-v20.12.2-linux-arm64/",
+        urls = ["https://nodejs.org/dist/v20.12.2/node-v20.12.2-linux-arm64.tar.gz"],
+        version = "20.12.2",
         architecture = "arm64",
         control = "//nodejs:control",
     )
 
     node_archive(
         name = "nodejs20_arm",
-        sha256 = "d4058aee344df896215eabbf367bbc9bf6504531e75016081565416c6e335e2a",
-        strip_prefix = "node-v20.12.1-linux-armv7l/",
-        urls = ["https://nodejs.org/dist/v20.12.1/node-v20.12.1-linux-armv7l.tar.gz"],
-        version = "20.12.1",
+        sha256 = "5861b891815ae8d42835db52bc57191858f348e0521b162c670c8ed4df417f1c",
+        strip_prefix = "node-v20.12.2-linux-armv7l/",
+        urls = ["https://nodejs.org/dist/v20.12.2/node-v20.12.2-linux-armv7l.tar.gz"],
+        version = "20.12.2",
         architecture = "arm",
         control = "//nodejs:control",
     )
 
     node_archive(
         name = "nodejs20_ppc64le",
-        sha256 = "f79c53a39c559e35da24e67a9ca85557bc54a0560a34bea67c4610ac7007ac0c",
-        strip_prefix = "node-v20.12.1-linux-ppc64le/",
-        urls = ["https://nodejs.org/dist/v20.12.1/node-v20.12.1-linux-ppc64le.tar.gz"],
-        version = "20.12.1",
+        sha256 = "c33968d78e06af64bd8d89a74781fef71ff126f862f7ed0ff2417d612dd64abb",
+        strip_prefix = "node-v20.12.2-linux-ppc64le/",
+        urls = ["https://nodejs.org/dist/v20.12.2/node-v20.12.2-linux-ppc64le.tar.gz"],
+        version = "20.12.2",
         architecture = "ppc64le",
         control = "//nodejs:control",
     )
 
     node_archive(
         name = "nodejs20_s390x",
-        sha256 = "2cc1c25374995aed79194a50166927dcb2b10473683407a173119d45c42de419",
-        strip_prefix = "node-v20.12.1-linux-s390x/",
-        urls = ["https://nodejs.org/dist/v20.12.1/node-v20.12.1-linux-s390x.tar.gz"],
-        version = "20.12.1",
+        sha256 = "29fe0d5142a3f3d7957d6ccf03cc08cd1c76c41d0460c92dd5800d46caa08d31",
+        strip_prefix = "node-v20.12.2-linux-s390x/",
+        urls = ["https://nodejs.org/dist/v20.12.2/node-v20.12.2-linux-s390x.tar.gz"],
+        version = "20.12.2",
         architecture = "s390x",
         control = "//nodejs:control",
     )

--- a/nodejs/testdata/nodejs18.yaml
+++ b/nodejs/testdata/nodejs18.yaml
@@ -3,4 +3,4 @@ commandTests:
   - name: nodejs
     command: "/nodejs/bin/node"
     args: ["--version"]
-    expectedOutput: ["v18.20.1"]
+    expectedOutput: ["v18.20.2"]

--- a/nodejs/testdata/nodejs20.yaml
+++ b/nodejs/testdata/nodejs20.yaml
@@ -3,4 +3,4 @@ commandTests:
   - name: nodejs
     command: "/nodejs/bin/node"
     args: ["--version"]
-    expectedOutput: ["v20.12.1"]
+    expectedOutput: ["v20.12.2"]


### PR DESCRIPTION
This fixes a vulnerability which including 1 high severity issue for the 20.x and 18.x release of nodejs.

more information: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2