### PR TITLE
Fix broken link in python3 README

### DIFF
--- a/python3/README.md
+++ b/python3/README.md
@@ -4,7 +4,7 @@
 
 This image contains a minimal Linux, Python-based runtime.
 
-Specifically, the image contains everything in the [base image](../../base/README.md), plus:
+Specifically, the image contains everything in the [base image](../base/README.md), plus:
 
 * Python 3 and its dependencies.
 * No shell and no support for ctypes


### PR DESCRIPTION
This PR is a very small fix about README.
I found a broken link in README in python3 directory, and I fix it.
