### PR TITLE
Update python3-requirements examble to debian12 and use fstring in Python Code

### DIFF
--- a/examples/python3-requirements/Dockerfile
+++ b/examples/python3-requirements/Dockerfile
@@ -2,7 +2,7 @@
 # * Install python3-venv for the built-in Python3 venv module (not installed by default)
 # * Install gcc libpython3-dev to compile C Python modules
 # * In the virtualenv: Update pip setuputils and wheel to support building new packages
-FROM debian:11-slim AS build
+FROM debian:12-slim AS build
 RUN apt-get update && \
     apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
     python3 -m venv /venv && \
@@ -14,7 +14,7 @@ COPY requirements.txt /requirements.txt
 RUN /venv/bin/pip install --disable-pip-version-check -r /requirements.txt
 
 # Copy the virtualenv into a distroless image
-FROM gcr.io/distroless/python3-debian11
+FROM gcr.io/distroless/python3-debian12
 COPY --from=build-venv /venv /venv
 COPY . /app
 WORKDIR /app

--- a/examples/python3-requirements/psutil_example.py
+++ b/examples/python3-requirements/psutil_example.py
@@ -13,8 +13,7 @@ def mib(total_bytes):
 def main():
     current_process = psutil.Process()
     memory = current_process.memory_info()
-    print('RSS: {:.1f} MiB;  SHARED: {:.1f} MiB; VIRTUAL: {:.1f} MiB'.format(
-        mib(memory.rss), mib(memory.shared), mib(memory.vms)))
+    print(f'RSS: {mib(memory.rss):.1f} MiB;  SHARED: {mib(memory.shared):.1f} MiB; VIRTUAL: {mib(memory.vms):.1f} MiB')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I have seen that the python3-requirements example still uses debian 11 which I have upgraded to debian 12.
I also replaced the `.format` with a fstring.