### PR TITLE
use bazelisk on cloudbuild

### DIFF
--- a/.cloudbuild/release.sh
+++ b/.cloudbuild/release.sh
@@ -8,10 +8,10 @@ chmod +x bazel-remote
 mkdir .logs
 ./bazel-remote --max_size 8 --dir ~/.cache/bazel-remote --experimental_remote_asset_api --grpc_address 0.0.0.0:4700 --gcs_proxy.bucket $REMOTE_CACHE_GCS --gcs_proxy.use_default_credentials > .logs/bazel-remote.log 2>&1 &
 
-# install bazel
-VERSION=$(cat .bazelversion)
-apt-get install "bazel-${VERSION}"
-ln -sf "/usr/bin/bazel-${VERSION}" /usr/bin/bazel
+# install bazelisk (TODO: there's probably a better way to do this)
+curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.21.0/bazelisk-linux-amd64 -o bazelisk
+echo '655a5c675dacf3b7ef4970688b6a54598aa30cbaa0b9e717cd1412c1ef9ec5a7 bazelisk' | sha256sum --check
+chmod a+x bazelisk
 
 # setup remote caching and remote asset API.
 echo "common --remote_cache=grpc://0.0.0.0:4700" >> ~/.bazelrc
@@ -20,6 +20,6 @@ echo "common --google_default_credentials" >> ~/.bazelrc
 echo "common --announce_rc" >> ~/.bazelrc
 
 for i in $(seq 5); do 
-    bazel cquery 'kind(merge_providers, deps(kind(oci_image, ...)))' --output=label --config=release && break || sleep 20;
+    ./bazelisk cquery 'kind(merge_providers, deps(kind(oci_image, ...)))' --output=label --config=release && break || sleep 20;
 done
-bazel run :sign_and_push --config=release -- --keyless $KEYLESS
+./bazelisk run :sign_and_push --config=release -- --keyless $KEYLESS


### PR DESCRIPTION
looks like the default apt repo doesn't have every single version of bazel on tap.