### PR TITLE
fix: the ownership of /home should be 0:0

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -143,8 +143,8 @@ home(
         },
         {
             "home": "/home",
-            "uid": NONROOT,
-            "gid": NONROOT,
+            "uid": ROOT,
+            "gid": ROOT,
             "mode": 755,
         },
         {


### PR DESCRIPTION
fix https://github.com/GoogleContainerTools/distroless/issues/1661