### PR TITLE
Fix dedup logic to handle different repos from the same image

### DIFF
--- a/private/oci/sign_and_push.bzl
+++ b/private/oci/sign_and_push.bzl
@@ -32,30 +32,29 @@ def _sign_and_push_impl(ctx):
         files = target[DefaultInfo].files.to_list()
 
         all_refs = ctx.attr.refs[image]
-        first_ref = all_refs[0]
-        repository_and_tag = first_ref.split(":")
-        cmds.append(
-            PUSH_AND_SIGN_CMD.format(
-                IMAGE = files[0].short_path,
-                SBOM = files[1].short_path,
-                DIGEST = files[2].short_path,
-                CRANE = ctx.file._crane.short_path,
-                COSIGN = ctx.file._cosign.short_path,
-                REPOSITORY = repository_and_tag[0],
-                TAG = repository_and_tag[1],
-            ),
-        )
-
-        for ref in all_refs[1:]:
+        for ref in all_refs:
             repository_and_tag = ref.split(":")
             cmds.append(
-                TAG_CMD.format(
-                    IMAGE = image,
-                    FROM = first_ref,
-                    TAG = repository_and_tag[1],
+                PUSH_AND_SIGN_CMD.format(
+                    IMAGE = files[0].short_path,
+                    SBOM = files[1].short_path,
+                    DIGEST = files[2].short_path,
                     CRANE = ctx.file._crane.short_path,
+                    COSIGN = ctx.file._cosign.short_path,
+                    REPOSITORY = repository_and_tag[0],
+                    TAG = repository_and_tag[1],
                 ),
             )
+
+            for tag in ctx.attr.more_tags[ref]:
+                cmds.append(
+                    TAG_CMD.format(
+                        IMAGE = image,
+                        FROM = ref,
+                        TAG = tag,
+                        CRANE = ctx.file._crane.short_path,
+                    ),
+                )
 
     executable = ctx.actions.declare_file("{}_sign_and_push.sh".format(ctx.label.name))
     ctx.actions.expand_template(
@@ -75,6 +74,7 @@ sign_and_push = rule(
     attrs = {
         "refs": attr.string_list_dict(mandatory = True),
         "targets": attr.string_keyed_label_dict(mandatory = True, cfg = "exec"),
+        "more_tags": attr.string_list_dict(mandatory = True),
         "_push_tpl": attr.label(default = "sign_and_push.sh.tpl", allow_single_file = True),
         "_crane": attr.label(allow_single_file = True, cfg = "exec", default = "@oci_crane_toolchains//:current_toolchain"),
         "_cosign": attr.label(allow_single_file = True, cfg = "exec", default = "@oci_cosign_toolchains//:current_toolchain"),
@@ -90,16 +90,31 @@ def sign_and_push_all(name, images):
         images: a dict where keys are fully qualified image reference and values are image label
     """
 
+    # since bazel doesn't allow dicts of dicts of lists as attrs, we have to write this nutty
+    # deduplication code
     dedup_image_dict = dict()
+    dedup_more_tags = dict()
     dedup_push_dict = dict()
 
     for (idx, (ref, image)) in enumerate(images.items()):
+        repository_and_tag = ref.split(":")
+        repository = repository_and_tag[0]
+        tag = repository_and_tag[1]
         if image in dedup_image_dict:
-            dedup_image_dict[image].append(ref)
+            foundPrefix = False
+            for oRef in dedup_image_dict[image]:
+                if oRef.split(":")[0] == repository:
+                    dedup_more_tags[oRef].append(tag)
+                    foundPrefix = True
+                    break
+            if not foundPrefix:
+                dedup_image_dict[image].append(ref)
+                dedup_more_tags[ref] = []
         else:
             dedup_image_dict[image] = [ref]
+            dedup_more_tags[ref] = []
 
-    for (idx, (image, ref)) in enumerate(dedup_image_dict.items()):
+    for (idx, (image, _)) in enumerate(dedup_image_dict.items()):
         oci_image_spdx(
             name = "{}_{}_sbom".format(name, idx),
             image = image,
@@ -124,10 +139,11 @@ def sign_and_push_all(name, images):
         name = name + ".query",
         content = [
             "{repo} {image}".format(
-                repo = refs[0],
+                repo = repo,
                 image = image,
             )
             for (image, refs) in dedup_image_dict.items()
+            for repo in refs
         ],
         out = name + "_query",
     )
@@ -135,5 +151,6 @@ def sign_and_push_all(name, images):
     sign_and_push(
         name = name,
         targets = dedup_push_dict,
+        more_tags = dedup_more_tags,
         refs = dedup_image_dict,
     )


### PR DESCRIPTION
gcr.io/distroless/(cc|cc-debian12):<tag>

since bazel doesn't allow dicts of dicts of lists in attrs this looks a bit crazy