### PR TITLE
Deprecate node18

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -177,7 +177,6 @@ PYTHON3 |= {
 
 ## NODEJS
 NODEJS_VERSIONS = [
-    "18",
     "20",
     "22",
 ]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -58,7 +58,7 @@ include("//private/repos:java.MODULE.bazel")
 ### NODE ###
 node = use_extension("//private/extensions:node.bzl", "node")
 node.archive()
-use_repo(node, "nodejs18_amd64", "nodejs18_arm", "nodejs18_arm64", "nodejs18_ppc64le", "nodejs18_s390x", "nodejs20_amd64", "nodejs20_arm", "nodejs20_arm64", "nodejs20_ppc64le", "nodejs20_s390x", "nodejs22_amd64", "nodejs22_arm", "nodejs22_arm64", "nodejs22_ppc64le", "nodejs22_s390x")
+use_repo(node, "nodejs20_amd64", "nodejs20_arm", "nodejs20_arm64", "nodejs20_ppc64le", "nodejs20_s390x", "nodejs22_amd64", "nodejs22_arm", "nodejs22_arm64", "nodejs22_ppc64le", "nodejs22_s390x")
 
 ### DEBIAN ###
 include("//private/repos/deb:deb.MODULE.bazel")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -373,82 +373,12 @@
     },
     "//private/extensions:node.bzl%node": {
       "general": {
-        "bzlTransitiveDigest": "QoJW/aMZawsoRG6IuqvZ/tVlbMpYuNAAxOJu/tiGJ/E=",
+        "bzlTransitiveDigest": "AIJARq6qX9w6hU8hd+3SsL+gPw2uGb9OEIYfh3TY6eE=",
         "usagesDigest": "oo4hnOxowfXXa21Wd8roJmpRdyG7Fy97FBO9vJoyK/M=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "nodejs18_amd64": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "27a9f3f14d5e99ad05a07ed3524ba3ee92f8ff8b6db5ff80b00f9feb5ec8097a",
-              "strip_prefix": "node-v18.20.8-linux-x64/",
-              "urls": [
-                "https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz"
-              ],
-              "version": "18.20.8",
-              "architecture": "amd64",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs18_arm64": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "2e3dfc51154e6fea9fc86a90c4ea8f3ecb8b60acaf7367c4b76691da192571c1",
-              "strip_prefix": "node-v18.20.8-linux-arm64/",
-              "urls": [
-                "https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-arm64.tar.gz"
-              ],
-              "version": "18.20.8",
-              "architecture": "arm64",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs18_arm": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "d09ea19ff5eb7b0ff47d80316c708092ac401c138254e018e21b89bb6ed9abd0",
-              "strip_prefix": "node-v18.20.8-linux-armv7l/",
-              "urls": [
-                "https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-armv7l.tar.gz"
-              ],
-              "version": "18.20.8",
-              "architecture": "arm",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs18_ppc64le": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "3c0c7e5f414c2123b185924e3afac3bc6fcc3edbe14ec2782e9d5210a76d8b8e",
-              "strip_prefix": "node-v18.20.8-linux-ppc64le/",
-              "urls": [
-                "https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-ppc64le.tar.gz"
-              ],
-              "version": "18.20.8",
-              "architecture": "ppc64le",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs18_s390x": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "6db3d48cabcb22f1f4af29633431b62d1040099a6e27182ad9f018c90f09d65b",
-              "strip_prefix": "node-v18.20.8-linux-s390x/",
-              "urls": [
-                "https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-s390x.tar.gz"
-              ],
-              "version": "18.20.8",
-              "architecture": "s390x",
-              "control": "@@//nodejs:control"
-            }
-          },
           "nodejs20_amd64": {
             "bzlFile": "@@//private/extensions:node.bzl",
             "ruleClassName": "node_archive",
@@ -592,11 +522,6 @@
         },
         "moduleExtensionMetadata": {
           "explicitRootModuleDirectDeps": [
-            "nodejs18_amd64",
-            "nodejs18_arm64",
-            "nodejs18_arm",
-            "nodejs18_ppc64le",
-            "nodejs18_s390x",
             "nodejs20_amd64",
             "nodejs20_arm64",
             "nodejs20_arm",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The following images are currently published and updated by the distroless proje
 | gcr.io/distroless/java-base-debian12  | latest, nonroot, debug, debug-nonroot | amd64, arm64, s390x, ppc64le      |
 | gcr.io/distroless/java17-debian12     | latest, nonroot, debug, debug-nonroot | amd64, arm64, s390x, ppc64le      |
 | gcr.io/distroless/java21-debian12     | latest, nonroot, debug, debug-nonroot | amd64, arm64, ppc64le             |
-| gcr.io/distroless/nodejs18-debian12   | latest, nonroot, debug, debug-nonroot | amd64, arm64, arm, s390x, ppc64le |
 | gcr.io/distroless/nodejs20-debian12   | latest, nonroot, debug, debug-nonroot | amd64, arm64, arm, s390x, ppc64le |
 | gcr.io/distroless/nodejs22-debian12   | latest, nonroot, debug, debug-nonroot | amd64, arm64, arm, s390x, ppc64le |
 

--- a/SUPPORT_POLICY.md
+++ b/SUPPORT_POLICY.md
@@ -21,7 +21,7 @@ The current estimation of end of life for images with the pattern:
 Java will only support current LTS version distributed by debian [see here](https://wiki.debian.org/Java).
 
 ### Node
-Node version support is for even numbered releases (18, 20, 22, etc) that are current, active or in LTS maintenance. For more information, [see here](https://nodejs.org/en/about/previous-releases#release-schedule).
+Node version support is for even numbered releases (20, 22, etc) that are current, active or in LTS maintenance. For more information, [see here](https://nodejs.org/en/about/previous-releases#release-schedule).
 
 ### Images no longer supported (TBD)
 A list of supported image tags is available here: https://github.com/GoogleContainerTools/distroless#what-images-are-available

--- a/examples/nodejs/BUILD
+++ b/examples/nodejs/BUILD
@@ -29,7 +29,7 @@ pkg_tar(
 [
     oci_image(
         name = "hello_" + user + "_" + arch + "_" + distro,
-        base = "//nodejs:nodejs18_" + user + "_" + arch + "_" + distro,
+        base = "//nodejs:nodejs22_" + user + "_" + arch + "_" + distro,
         cmd = ["hello.js"],
         tars = [":hello_tar"],
     )
@@ -44,7 +44,7 @@ pkg_tar(
 [
     oci_image(
         name = "hello_http_" + user + "_" + arch + "_" + distro,
-        base = "//nodejs:nodejs18_" + user + "_" + arch + "_" + distro,
+        base = "//nodejs:nodejs22_" + user + "_" + arch + "_" + distro,
         cmd = ["hello_http.js"],
         tars = [":hello_http_tar"],
     )

--- a/examples/nodejs/Dockerfile
+++ b/examples/nodejs/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:20 AS build-env
+FROM node:22 AS build-env
 COPY . /app
 WORKDIR /app
 
 RUN npm ci --omit=dev
 
-FROM gcr.io/distroless/nodejs20-debian12
+FROM gcr.io/distroless/nodejs22-debian12
 COPY --from=build-env /app /app
 WORKDIR /app
 CMD ["hello.js"]

--- a/examples/nodejs/node-express/Dockerfile
+++ b/examples/nodejs/node-express/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:20 AS build-env
+FROM node:22 AS build-env
 ADD . /app
 WORKDIR /app
 RUN npm install --omit=dev
 
-FROM gcr.io/distroless/nodejs20-debian12
+FROM gcr.io/distroless/nodejs22-debian12
 COPY --from=build-env /app /app
 WORKDIR /app
 EXPOSE 3000

--- a/nodejs/BUILD
+++ b/nodejs/BUILD
@@ -6,7 +6,7 @@ load("//base:distro.bzl", "DISTROS")
 
 package(default_visibility = ["//visibility:public"])
 
-NODEJS_MAJOR_VERISONS = ("18", "20", "22")
+NODEJS_MAJOR_VERISONS = ("20", "22")
 
 MODE = [
     "",

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -6,7 +6,6 @@ These images contain a minimal Linux, Node.js-based runtime. The supported versi
 
 Specifically, these images contain everything in the [base image](../base/README.md), plus one of:
 
-- Node.js v18 (`gcr.io/distroless/nodejs18-debian12`) and its dependencies.
 - Node.js v20 (`gcr.io/distroless/nodejs20-debian12`) and its dependencies.
 - Node.js v22 (`gcr.io/distroless/nodejs22-debian12`) and its dependencies.
 

--- a/nodejs/testdata/nodejs18.yaml
+++ b/nodejs/testdata/nodejs18.yaml
@@ -1,6 +1,0 @@
-schemaVersion: "2.0.0"
-commandTests:
-  - name: nodejs
-    command: "/nodejs/bin/node"
-    args: ["--version"]
-    expectedOutput: ["v18.20.8"]

--- a/private/extensions/node.bzl
+++ b/private/extensions/node.bzl
@@ -98,56 +98,6 @@ def _node_impl(module_ctx):
     # Follow Node's maintainence schedule and support all LTS versions that are not end of life
 
     node_archive(
-        name = "nodejs18_amd64",
-        sha256 = "27a9f3f14d5e99ad05a07ed3524ba3ee92f8ff8b6db5ff80b00f9feb5ec8097a",
-        strip_prefix = "node-v18.20.8-linux-x64/",
-        urls = ["https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-x64.tar.gz"],
-        version = "18.20.8",
-        architecture = "amd64",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs18_arm64",
-        sha256 = "2e3dfc51154e6fea9fc86a90c4ea8f3ecb8b60acaf7367c4b76691da192571c1",
-        strip_prefix = "node-v18.20.8-linux-arm64/",
-        urls = ["https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-arm64.tar.gz"],
-        version = "18.20.8",
-        architecture = "arm64",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs18_arm",
-        sha256 = "d09ea19ff5eb7b0ff47d80316c708092ac401c138254e018e21b89bb6ed9abd0",
-        strip_prefix = "node-v18.20.8-linux-armv7l/",
-        urls = ["https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-armv7l.tar.gz"],
-        version = "18.20.8",
-        architecture = "arm",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs18_ppc64le",
-        sha256 = "3c0c7e5f414c2123b185924e3afac3bc6fcc3edbe14ec2782e9d5210a76d8b8e",
-        strip_prefix = "node-v18.20.8-linux-ppc64le/",
-        urls = ["https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-ppc64le.tar.gz"],
-        version = "18.20.8",
-        architecture = "ppc64le",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs18_s390x",
-        sha256 = "6db3d48cabcb22f1f4af29633431b62d1040099a6e27182ad9f018c90f09d65b",
-        strip_prefix = "node-v18.20.8-linux-s390x/",
-        urls = ["https://nodejs.org/dist/v18.20.8/node-v18.20.8-linux-s390x.tar.gz"],
-        version = "18.20.8",
-        architecture = "s390x",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
         name = "nodejs20_amd64",
         sha256 = "086ab500a98900a4c05127559b2cec4d659b3aa674453be5028d416de4eb1532",
         strip_prefix = "node-v20.19.1-linux-x64/",
@@ -249,11 +199,6 @@ def _node_impl(module_ctx):
 
     return module_ctx.extension_metadata(
         root_module_direct_deps = [
-            "nodejs18_amd64",
-            "nodejs18_arm64",
-            "nodejs18_arm",
-            "nodejs18_ppc64le",
-            "nodejs18_s390x",
             "nodejs20_amd64",
             "nodejs20_arm64",
             "nodejs20_arm",


### PR DESCRIPTION
Nodejs 18 was deprecated today, and can be removed.