### PR TITLE
feat(java): add Java 25 support on all architectures

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,7 @@
 load("//:checksums.bzl", "ARCHITECTURES", "BASE_ARCHITECTURES")
 load("//base:distro.bzl", "DISTROS")
-load("//private/oci:defs.bzl", "sign_and_push_all")
 load("//nodejs:node_arch.bzl", "node_arch")
+load("//private/oci:defs.bzl", "sign_and_push_all")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -279,16 +279,10 @@ JAVA17 |= {
 }
 
 ## JAVA 21 from temurin
-JAVA_21_ARCHITECTURES = [
-    "amd64",
-    "arm64",
-    "ppc64le",
-]
-
 JAVA21 = {
     "{REGISTRY}/{PROJECT_ID}/java21-debian12:" + tag_base + "-" + arch: "//java:java21_" + label + "_" + arch + "_debian12"
     for (tag_base, label) in JAVA_VARIATIONS
-    for arch in JAVA_21_ARCHITECTURES
+    for arch in JAVA_ARCHITECTURES
 }
 
 # oci_image_index
@@ -299,6 +293,24 @@ JAVA21 |= {
 
 JAVA21 |= {
     "{REGISTRY}/{PROJECT_ID}/java21-debian12:" + tag_base: "//java:java21_" + label + "_debian12"
+    for (tag_base, label) in JAVA_VARIATIONS
+}
+
+## Java 25 from temurin
+JAVA25 = {
+    "{REGISTRY}/{PROJECT_ID}/java25-debian12:" + tag_base + "-" + arch: "//java:java25_" + label + "_" + arch + "_debian12"
+    for (tag_base, label) in JAVA_VARIATIONS
+    for arch in JAVA_ARCHITECTURES
+}
+
+# oci_image_index
+JAVA25 |= {
+    "{REGISTRY}/{PROJECT_ID}/java25:" + tag_base: "//java:java25_" + label + "_" + DEFAULT_DISTRO
+    for (tag_base, label) in JAVA_VARIATIONS
+}
+
+JAVA25 |= {
+    "{REGISTRY}/{PROJECT_ID}/java25-debian12:" + tag_base: "//java:java25_" + label + "_debian12"
     for (tag_base, label) in JAVA_VARIATIONS
 }
 
@@ -321,6 +333,8 @@ ALL |= JAVA_BASE
 ALL |= JAVA17
 
 ALL |= JAVA21
+
+ALL |= JAVA25
 
 # create additional tags by appending COMMIT_SHA to all tags
 # remove "latest" if they contain it (this is brittle if we make funky changes):

--- a/java/BUILD
+++ b/java/BUILD
@@ -22,13 +22,6 @@ JAVA_ARCHITECTURES = [
     "ppc64le",
 ]
 
-JAVA_21_ARCHITECTURES = [
-    "amd64",
-    "arm64",
-    # "s390x", adoptium doesn't have a build yet
-    "ppc64le",
-]
-
 JAVA_VERSIONS_PER_DISTRO = [
     ("17", "debian12"),
 ]
@@ -60,7 +53,7 @@ JAVA_VERSIONS_PER_DISTRO = [
     for java_version, distro in JAVA_VERSIONS_PER_DISTRO
 ]
 
-# special case for java 21, we will start using temurin, the goal is to slowly transition all builds
+# special case for java 21 and 25, we will start using temurin, the goal is to slowly transition all builds
 # to temurin, to also back support java 11 on debian12.
 [
     pkg_tar(
@@ -72,8 +65,8 @@ JAVA_VERSIONS_PER_DISTRO = [
             "@temurin" + java_version + "_jre_" + arch,
         ],
     )
-    for arch in JAVA_21_ARCHITECTURES
-    for java_version in ["21"]
+    for arch in JAVA_ARCHITECTURES
+    for java_version in ["21", "25"]
 ]
 
 [
@@ -86,8 +79,8 @@ JAVA_VERSIONS_PER_DISTRO = [
             "@temurin" + java_version + "_jdk_" + arch,
         ],
     )
-    for arch in JAVA_21_ARCHITECTURES
-    for java_version in ["21"]
+    for arch in JAVA_ARCHITECTURES
+    for java_version in ["21", "25"]
 ]
 
 # Base
@@ -248,17 +241,17 @@ JAVA_VERSIONS_PER_DISTRO = [
     for java_version, distro in JAVA_VERSIONS_PER_DISTRO
 ]
 
-# Temurin Java 21
+# Temurin Java 21 & 25
 [
     oci_image_index(
         name = "java" + java_version + "_" + user + "_" + distro,
         images = [
             "java" + java_version + "_" + user + "_" + arch + "_" + distro
-            for arch in JAVA_21_ARCHITECTURES
+            for arch in JAVA_ARCHITECTURES
         ],
     )
     for user in USERS
-    for java_version, distro in [("21", "debian12")]
+    for java_version, distro in [("21", "debian12"), ("25", "debian12")]
 ]
 
 [
@@ -278,22 +271,22 @@ JAVA_VERSIONS_PER_DISTRO = [
             ":temurin_jre_" + java_version + "_" + arch,
         ],
     )
-    for arch in JAVA_21_ARCHITECTURES
+    for arch in JAVA_ARCHITECTURES
     for user in USERS
-    for java_version, distro in [("21", "debian12")]
+    for java_version, distro in [("21", "debian12"), ("25", "debian12")]
 ]
 
-# Temurin Java 21 Debug
+# Temurin Java 21 & 25 Debug
 [
     oci_image_index(
         name = "java" + java_version + "_debug_" + user + "_" + distro,
         images = [
             "java" + java_version + "_debug_" + user + "_" + arch + "_" + distro
-            for arch in JAVA_21_ARCHITECTURES
+            for arch in JAVA_ARCHITECTURES
         ],
     )
     for user in USERS
-    for java_version, distro in [("21", "debian12")]
+    for java_version, distro in [("21", "debian12"), ("25", "debian12")]
 ]
 
 [
@@ -314,8 +307,8 @@ JAVA_VERSIONS_PER_DISTRO = [
         ],
     )
     for user in USERS
-    for arch in JAVA_21_ARCHITECTURES
-    for java_version, distro in [("21", "debian12")]
+    for arch in JAVA_ARCHITECTURES
+    for java_version, distro in [("21", "debian12"), ("25", "debian12")]
 ]
 
 [
@@ -348,8 +341,8 @@ JAVA_VERSIONS_PER_DISTRO = [
         ],
     )
     for user in USERS
-    for java_version, distro in JAVA_VERSIONS_PER_DISTRO + [("21", "debian12")]
-    for arch in (JAVA_ARCHITECTURES if java_version != "21" else JAVA_21_ARCHITECTURES)
+    for java_version, distro in JAVA_VERSIONS_PER_DISTRO + [("21", "debian12"), ("25", "debian12")]
+    for arch in JAVA_ARCHITECTURES
 ]
 
 [
@@ -363,8 +356,8 @@ JAVA_VERSIONS_PER_DISTRO = [
         ],
     )
     for user in USERS
-    for java_version, distro in JAVA_VERSIONS_PER_DISTRO + [("21", "debian12")]
-    for arch in (JAVA_ARCHITECTURES if java_version != "21" else JAVA_21_ARCHITECTURES)
+    for java_version, distro in JAVA_VERSIONS_PER_DISTRO + [("21", "debian12") , ("25", "debian12")]
+    for arch in JAVA_ARCHITECTURES
 ]
 
 RULE_NAMES = [
@@ -372,6 +365,8 @@ RULE_NAMES = [
     ("java17_nonroot_debian12", "java17_nonroot_amd64_debian12"),
     ("java21_root_debian12", "java21_root_amd64_debian12"),
     ("java21_nonroot_debian12", "java21_nonroot_amd64_debian12"),
+    ("java25_root_debian12", "java25_root_amd64_debian12"),
+    ("java25_nonroot_debian12", "java25_nonroot_amd64_debian12"),
 ]
 
 [

--- a/java/README.md
+++ b/java/README.md
@@ -8,7 +8,7 @@ Specifically, the image contains everything in the [base image](../base/README.m
 
 * OpenJDK 17 (`gcr.io/distroless/java17-debian12`) and its dependencies.
 * Temurin OpenJDK 21 (`gcr.io/distroless/java21-debian12`) and its dependencies
-
+* Temurin OpenJDK 25 (`gcr.io/distroless/java25-debian12`) and its dependencies
 
 ## Usage
 

--- a/java/testdata/java25_debian12.yaml
+++ b/java/testdata/java25_debian12.yaml
@@ -1,0 +1,39 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: java
+    command: "/usr/lib/jvm/temurin25_jre_amd64/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "25.0.0"']
+  - name: java-symlink
+    command: "/usr/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "25.0.0"']
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: certs
+    path: "/usr/lib/jvm/temurin25_jre_amd64/lib/security/cacerts"
+    permissions: 'Lrwxrwxrwx'
+    shouldExist: true
+  - name: no-busybox
+    path: "/busybox/sh"
+    shouldExist: false
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+  - name: no-javac
+    path: "/usr/lib/jvm/temurin25_jre_amd64/bin/javac"
+    shouldExist: false
+  - name: jexec-executable
+    path: "/usr/lib/jvm/temurin25_jre_amd64/lib/jexec"
+    shouldExist: true
+    isExecutableBy: "any"
+  - name: jspawnhelper-executable
+    path: "/usr/lib/jvm/temurin25_jre_amd64/lib/jspawnhelper"
+    shouldExist: true
+    isExecutableBy: "any"
+metadataTest:
+  envVars:
+    - key: 'JAVA_VERSION'
+      value: '25.0.0'

--- a/java/testdata/java25_debug_debian12.yaml
+++ b/java/testdata/java25_debug_debian12.yaml
@@ -1,0 +1,32 @@
+schemaVersion: "2.0.0"
+commandTests:
+  - name: java
+    command: "/usr/lib/jvm/temurin25_jdk_amd64/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "25.0.0"']
+  - name: java-symlink
+    command: "/usr/bin/java"
+    args: ["-version"]
+    expectedError: ['openjdk version "25.0.0"']
+  - name: javac
+    command: "/usr/lib/jvm/temurin25_jdk_amd64/bin/javac"
+    args: ["-version"]
+    expectedOutput: ['javac 25.0.0']
+fileExistenceTests:
+  - name: certs
+    path: "/etc/ssl/certs/java/cacerts"
+    shouldExist: true
+  - name: certs
+    path: "/usr/lib/jvm/temurin25_jdk_amd64/lib/security/cacerts"
+    permissions: 'Lrwxrwxrwx'
+    shouldExist: true
+  - name: busybox
+    path: "/busybox/sh"
+    shouldExist: true
+  - name: no-shell
+    path: "/bin/sh"
+    shouldExist: false
+metadataTest:
+  envVars:
+    - key: 'JAVA_VERSION'
+      value: '25.0.0'


### PR DESCRIPTION
Note: This is a draft pull request until Eclipse Temurin releases Java 25 [docker tags](https://hub.docker.com/_/eclipse-temurin/tags).

Would fix #1869

# What has been done
- Replace `JAVA21_ARCHITECTURES` with `JAVA_ARCHITECTURES`  as Java 21 supports s390x, will fix #1828
- java/BUILD: Add `("25", "debian12")` arguments on the Java 21 new architectures.
- BUILD: Add `JAVA25` variable following `JAVA21` template

# Point of attention
- I'm expecting every java architecture to be available for Eclipse Temurin, but if it's not the case and we want to move along, then the deleted `JAVA21_ARCHITECTURES` list would be renamed to `JAVA25_ARCHITECTURES` to add the supported architectures.
- I don't have access to the `JAVA_VERSIONS` so the build process is blocked already.

Feel free to share suggestions or improvement.