### PR TITLE
Bump go to 1.25 in image-check and buildifier workflows

### DIFF
--- a/.github/workflows/buildifier.yaml
+++ b/.github/workflows/buildifier.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.25"
 
       - name: Check out code
         uses: actions/checkout@v5

--- a/.github/workflows/image-check.yaml
+++ b/.github/workflows/image-check.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.25"
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
The new `github.com/google/go-containerregistry/cmd/crane` is requiring [Go version 1.24](https://github.com/google/go-containerregistry/blob/59a4b85930392a30c39462519adc8a2026d47181/go.mod#L3). Let's upgrade all Go versions in workflows to latest (1.25)

This will also fix the CI in https://github.com/GoogleContainerTools/distroless/pull/1861