### PR TITLE
docs: fix broken links to rules_distroless docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ See here for:
 See here for examples on how to complete some common tasks in your image:
 
 - [Adding and running as a non-root user](examples/nonroot)
-- [Including Debian Packages](https://github.com/GoogleContainerTools/rules_distroless/blob/main/docs/apt.md)
-- [Including CA certificates](https://github.com/GoogleContainerTools/rules_distroless/blob/main/docs/rules.md#cacerts)
+- [Including Debian Packages](https://registry.bazel.build/docs/rules_distroless#module_extension-apt)
+- [Including CA certificates](https://registry.bazel.build/docs/rules_distroless#rule-cacerts)
 
 See here for more information on how these images are [built and released](RELEASES.md).
 


### PR DESCRIPTION
In bazel-contrib/rules_distroless, it seems that the generated .md files are no longer included in the repository.
I updated the links to point to the published registry.bazel.build instead.

- related: https://github.com/bazel-contrib/rules_distroless/issues/195