### PR TITLE
docs: update ldd link from HTTP to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ BUILD       Dockerfile  hello.py
 
 > Note: If the image you are using already has a tag, for example `gcr.io/distroless/java17-debian12:nonroot`, use the tag `debug-<existing tag>` instead, for example `gcr.io/distroless/java17-debian12:debug-nonroot`.
 
-> Note: [ldd](http://man7.org/linux/man-pages/man1/ldd.1.html) is not installed in the base image as it's a shell script, you can copy it in or download it.
+> Note: [ldd](https://man7.org/linux/man-pages/man1/ldd.1.html) is not installed in the base image as it's a shell script, you can copy it in or download it.
 
 ### Who uses Distroless?
 


### PR DESCRIPTION
Update the ldd man page link in README.md from `http://` to `https://`.

The man7.org site supports HTTPS, so this ensures users aren't redirected through an insecure connection.