### PR TITLE
docs: update README to reflect Debian 13 as new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ See here for more information on how these images are [built and released](RELEA
 
 ### Base Operating System
 
-Distroless images are based on Debian 12 (bookworm). Images are explicitly tagged with Debian version suffixes (e.g. `-debian12`). Specifying an image without the distribution will currently select `-debian12` images, but that will change in the future to a newer version of Debian. It can be useful to reference the distribution explicitly, to prevent breaking builds when the next Debian version is released.
+Distroless images are based on Debian 13 (trixie). Images are explicitly tagged with Debian version suffixes (e.g. `-debian13`). Specifying an image without the distribution will currently select `-debian13` images. It can be useful to reference the distribution explicitly, to prevent breaking builds when the next Debian version is released.
 
 ### Operating System Updates for Security Fixes and CVEs
 


### PR DESCRIPTION
## Summary

PR #1987 changed `DEFAULT_DISTRO` to `debian13`, but the README was not updated. The "Base Operating System" section still says:

> Distroless images are based on Debian 12 (bookworm)... will currently select `-debian12` images

This is causing user confusion (see #1996) since the untagged images now resolve to Debian 13.

This PR updates the README to reflect the current default.

## Changes

- Updated Debian version from 12 (bookworm) to 13 (trixie)
- Updated example suffix from `-debian12` to `-debian13`
- Removed "but that will change in the future" since the change already happened