### PR TITLE
docs: fix incorrect debian version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Follow either of the two links above to access the appropriate CLA and instructi
 
 ## How to Build and Test
 
-1. `bazel build //...` to build the whole project or ex:`bazel build //base:static_root_amd64_debian17` for a single image
+1. `bazel build //...` to build the whole project or ex:`bazel build //base:static_root_amd64_debian13` for a single image
 
 2. For running tests, check `./knife test`. (`bazel test //...` will NOT run all tests, as many tests are marked "manual".)
 
@@ -24,7 +24,7 @@ load("@rules_oci//oci:defs.bzl", "oci_load")
 
 oci_load(
   name = "local_build",
-  image = "//base:static_root_amd64_debian17",
+  image = "//base:static_root_amd64_debian13",
   repo_tags = [],
 )
 ```


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` references `debian17` in build examples (lines 16 and 27), which doesn't exist. The current default distro is `debian13` (since PR #1987). 

This fixes both occurrences to use `debian13` so new contributors can follow the examples correctly.

## Changes

- `bazel build //base:static_root_amd64_debian17` → `debian13`
- `oci_load` example image reference updated to `debian13`