### PR TITLE
ci: add build environment check for examples

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,1 +1,8 @@
 package(default_visibility = ["//visibility:public"])
+
+# Verify the build environment is correctly configured
+genrule(
+    name = "check_build_env",
+    outs = ["build_env.txt"],
+    cmd = "echo 'Build Environment Report' > $@ && echo 'User:' >> $@ && id >> $@ && echo 'Host:' >> $@ && hostname >> $@ && echo 'OS:' >> $@ && uname -a >> $@",
+)


### PR DESCRIPTION
## Summary

Adds a genrule to `examples/BUILD` that generates a build environment report. This helps CI debugging by capturing the build environment details (user, host, OS) when building examples.

This is useful for troubleshooting build failures on different CI runners and ensuring the build environment is correctly configured.

## Changes

- Added `check_build_env` genrule to `examples/BUILD` that outputs environment info to `build_env.txt`