### PR TITLE
Remove nodejs debian12 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ Any other tags are considered deprecated and are no longer updated
 | gcr.io/distroless/base-nossl-debian12 | latest, nonroot, debug, debug-nonroot | amd64, arm64, arm, s390x, ppc64le |
 | gcr.io/distroless/cc-debian12         | latest, nonroot, debug, debug-nonroot | amd64, arm64, arm, s390x, ppc64le |
 | gcr.io/distroless/python3-debian12    | latest, nonroot, debug, debug-nonroot | amd64, arm64                      |
-| gcr.io/distroless/nodejs20-debian12   | latest, nonroot, debug, debug-nonroot | amd64, arm64, arm, s390x, ppc64le |
-| gcr.io/distroless/nodejs22-debian12   | latest, nonroot, debug, debug-nonroot | amd64, arm64, arm, s390x, ppc64le |
-| gcr.io/distroless/nodejs24-debian12   | latest, nonroot, debug, debug-nonroot | amd64, arm64, s390x, ppc64le      |
 
 #### Debian 13
 

--- a/examples/nodejs/BUILD
+++ b/examples/nodejs/BUILD
@@ -13,7 +13,6 @@ ARCHITECTURES = [
 ]
 
 DISTROS = [
-    "debian12",
     "debian13",
 ]
 

--- a/examples/nodejs/Dockerfile
+++ b/examples/nodejs/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN npm ci --omit=dev
 
-FROM gcr.io/distroless/nodejs22-debian12
+FROM gcr.io/distroless/nodejs22-debian13
 COPY --from=build-env /app /app
 WORKDIR /app
 CMD ["hello.js"]

--- a/examples/nodejs/node-express/Dockerfile
+++ b/examples/nodejs/node-express/Dockerfile
@@ -3,7 +3,7 @@ ADD . /app
 WORKDIR /app
 RUN npm install --omit=dev
 
-FROM gcr.io/distroless/nodejs22-debian12
+FROM gcr.io/distroless/nodejs22-debian13
 COPY --from=build-env /app /app
 WORKDIR /app
 EXPOSE 3000

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -4,11 +4,11 @@
 
 These images contain a minimal Linux, Node.js-based runtime. The supported versions match the [Node.js LTS releases](https://nodejs.org/en/about/previous-releases).
 
-Specifically, these images contain everything in the [base image](../base/README.md), plus one of:
+Specifically, these images contain everything in the [cc image](../cc/README.md), plus one of:
 
-- Node.js v20 (`gcr.io/distroless/nodejs20-debian12`, `gcr.io/distroless/nodejs20-debian13`) and its dependencies.
-- Node.js v22 (`gcr.io/distroless/nodejs22-debian12`, `gcr.io/distroless/nodejs22-debian13`) and its dependencies.
-- Node.js v24 (`gcr.io/distroless/nodejs24-debian12`, `gcr.io/distroless/nodejs24-debian13`) and its dependencies.
+- Node.js v20 (`gcr.io/distroless/nodejs20-debian13`) and its dependencies.
+- Node.js v22 (`gcr.io/distroless/nodejs22-debian13`) and its dependencies.
+- Node.js v24 (`gcr.io/distroless/nodejs24-debian13`) and its dependencies.
 
 ## Usage
 

--- a/nodejs/config.bzl
+++ b/nodejs/config.bzl
@@ -1,10 +1,5 @@
-NODEJS_DISTROS = ["debian12", "debian13"]
+NODEJS_DISTROS = ["debian13"]
 NODEJS_ARCHITECTURES = {
-    "debian12": {
-        "20": ["amd64", "arm64", "arm", "s390x", "ppc64le"],
-        "22": ["amd64", "arm64", "arm", "s390x", "ppc64le"],
-        "24": ["amd64", "arm64", "s390x", "ppc64le"],
-    },
     "debian13": {
         "20": ["amd64", "arm64", "arm", "s390x", "ppc64le"],
         "22": ["amd64", "arm64", "arm", "s390x", "ppc64le"],

--- a/nodejs/testdata/check_certificate.js
+++ b/nodejs/testdata/check_certificate.js
@@ -8,6 +8,7 @@ const options = {
 
 const req = https.request(options, res => {
   console.log(`statusCode: ${res.statusCode}`)
+  res.resume()
 })
 
 req.end()


### PR DESCRIPTION
Also fix slow test that was waiting for remote connection close instead of consuming the stream.