### PR TITLE
Remove EOL node20

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,7 +48,7 @@ use_repo(busybox, "busybox_amd64", "busybox_arm", "busybox_arm64", "busybox_ppc6
 ### NODE ###
 node = use_extension("//private/extensions:node.bzl", "node")
 node.archive()
-use_repo(node, "nodejs20_amd64", "nodejs20_arm", "nodejs20_arm64", "nodejs20_ppc64le", "nodejs20_s390x", "nodejs22_amd64", "nodejs22_arm", "nodejs22_arm64", "nodejs22_ppc64le", "nodejs22_s390x", "nodejs24_amd64", "nodejs24_arm64", "nodejs24_ppc64le", "nodejs24_s390x")
+use_repo(node, "nodejs22_amd64", "nodejs22_arm", "nodejs22_arm64", "nodejs22_ppc64le", "nodejs22_s390x", "nodejs24_amd64", "nodejs24_arm64", "nodejs24_ppc64le", "nodejs24_s390x")
 
 ### DEBIAN ###
 include("//private/repos/deb:deb.MODULE.bazel")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,7 +47,7 @@ use_repo(busybox, "busybox_amd64", "busybox_arm", "busybox_arm64", "busybox_ppc6
 ### NODE ###
 node = use_extension("//private/extensions:node.bzl", "node")
 node.archive()
-use_repo(node, "nodejs20_amd64", "nodejs20_arm", "nodejs20_arm64", "nodejs20_ppc64le", "nodejs20_s390x", "nodejs22_amd64", "nodejs22_arm", "nodejs22_arm64", "nodejs22_ppc64le", "nodejs22_s390x", "nodejs24_amd64", "nodejs24_arm64", "nodejs24_ppc64le", "nodejs24_s390x")
+use_repo(node, "nodejs22_amd64", "nodejs22_arm", "nodejs22_arm64", "nodejs22_ppc64le", "nodejs22_s390x", "nodejs24_amd64", "nodejs24_arm64", "nodejs24_ppc64le", "nodejs24_s390x")
 
 ### DEBIAN ###
 include("//private/repos/deb:deb.MODULE.bazel")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -346,82 +346,12 @@
     },
     "//private/extensions:node.bzl%node": {
       "general": {
-        "bzlTransitiveDigest": "QzpKKTow/8MX+N2b9MWRyh0SVQxJlKWKNg06gWs+aZc=",
+        "bzlTransitiveDigest": "0M3sw6FfsxoHCy9Q2CzdJDN/mvEuHbZEhgG/LUoIPjk=",
         "usagesDigest": "oo4hnOxowfXXa21Wd8roJmpRdyG7Fy97FBO9vJoyK/M=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "nodejs20_amd64": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b",
-              "strip_prefix": "node-v20.20.2-linux-x64/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-x64.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "amd64",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs20_arm64": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d",
-              "strip_prefix": "node-v20.20.2-linux-arm64/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-arm64.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "arm64",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs20_arm": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "8e15f121e721c9354132053188d4c1a18ea9e345c019ee440fb256e3dda7df15",
-              "strip_prefix": "node-v20.20.2-linux-armv7l/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-armv7l.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "arm",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs20_ppc64le": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "5f2fd0e0cd67aeac0db800b334151cae6ea70ea337487b26f79ac90e3fe126e1",
-              "strip_prefix": "node-v20.20.2-linux-ppc64le/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-ppc64le.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "ppc64le",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs20_s390x": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "ee1ca1193e75a6d31b6007c575deca11b116e84a6bda136ae0e0dbe19399889c",
-              "strip_prefix": "node-v20.20.2-linux-s390x/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-s390x.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "s390x",
-              "control": "@@//nodejs:control"
-            }
-          },
           "nodejs22_amd64": {
             "bzlFile": "@@//private/extensions:node.bzl",
             "ruleClassName": "node_archive",
@@ -551,11 +481,6 @@
         },
         "moduleExtensionMetadata": {
           "explicitRootModuleDirectDeps": [
-            "nodejs20_amd64",
-            "nodejs20_arm64",
-            "nodejs20_arm",
-            "nodejs20_ppc64le",
-            "nodejs20_s390x",
             "nodejs22_amd64",
             "nodejs22_arm64",
             "nodejs22_arm",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -344,82 +344,12 @@
     },
     "//private/extensions:node.bzl%node": {
       "general": {
-        "bzlTransitiveDigest": "XPG7mmj1w2JeWOpPfCt53gI44RsUyM+SbjzH6sh5S5E=",
+        "bzlTransitiveDigest": "+TaDMEEh3DzRHNaUPs7A8DxTrnXccxj0NkPbcihD0gY=",
         "usagesDigest": "oo4hnOxowfXXa21Wd8roJmpRdyG7Fy97FBO9vJoyK/M=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "nodejs20_amd64": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b",
-              "strip_prefix": "node-v20.20.2-linux-x64/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-x64.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "amd64",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs20_arm64": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d",
-              "strip_prefix": "node-v20.20.2-linux-arm64/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-arm64.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "arm64",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs20_arm": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "8e15f121e721c9354132053188d4c1a18ea9e345c019ee440fb256e3dda7df15",
-              "strip_prefix": "node-v20.20.2-linux-armv7l/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-armv7l.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "arm",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs20_ppc64le": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "5f2fd0e0cd67aeac0db800b334151cae6ea70ea337487b26f79ac90e3fe126e1",
-              "strip_prefix": "node-v20.20.2-linux-ppc64le/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-ppc64le.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "ppc64le",
-              "control": "@@//nodejs:control"
-            }
-          },
-          "nodejs20_s390x": {
-            "bzlFile": "@@//private/extensions:node.bzl",
-            "ruleClassName": "node_archive",
-            "attributes": {
-              "sha256": "ee1ca1193e75a6d31b6007c575deca11b116e84a6bda136ae0e0dbe19399889c",
-              "strip_prefix": "node-v20.20.2-linux-s390x/",
-              "urls": [
-                "https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-s390x.tar.gz"
-              ],
-              "version": "20.20.2",
-              "architecture": "s390x",
-              "control": "@@//nodejs:control"
-            }
-          },
           "nodejs22_amd64": {
             "bzlFile": "@@//private/extensions:node.bzl",
             "ruleClassName": "node_archive",
@@ -549,11 +479,6 @@
         },
         "moduleExtensionMetadata": {
           "explicitRootModuleDirectDeps": [
-            "nodejs20_amd64",
-            "nodejs20_arm64",
-            "nodejs20_arm",
-            "nodejs20_ppc64le",
-            "nodejs20_s390x",
             "nodejs22_amd64",
             "nodejs22_arm64",
             "nodejs22_arm",

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Debian 13 distroless images use the debian [UsrMerge](https://wiki.debian.org/Us
 | gcr.io/distroless/java17-debian13     | latest, nonroot, debug, debug-nonroot | amd64, arm64, s390x, ppc64le, riscv64      |
 | gcr.io/distroless/java21-debian13     | latest, nonroot, debug, debug-nonroot | amd64, arm64, s390x, ppc64le, riscv64      |
 | gcr.io/distroless/java25-debian13     | latest, nonroot, debug, debug-nonroot | amd64, arm64, s390x, ppc64le, riscv64      |
-| gcr.io/distroless/nodejs20-debian13   | latest, nonroot, debug, debug-nonroot | amd64, arm64, arm, s390x, ppc64le          |
 | gcr.io/distroless/nodejs22-debian13   | latest, nonroot, debug, debug-nonroot | amd64, arm64, arm, s390x, ppc64le          |
 | gcr.io/distroless/nodejs24-debian13   | latest, nonroot, debug, debug-nonroot | amd64, arm64, s390x, ppc64le               |
 | gcr.io/distroless/python3-debian13    | latest, nonroot, debug, debug-nonroot | amd64, arm64, riscv64                      |

--- a/SUPPORT_POLICY.md
+++ b/SUPPORT_POLICY.md
@@ -21,7 +21,7 @@ The current estimation of end of life for images with the pattern:
 Java will only support current LTS version distributed by debian [see here](https://wiki.debian.org/Java).
 
 ### Node
-Node version support is for even numbered releases (20, 22, 24, etc) that are current, active or in LTS maintenance. For more information, [see here](https://nodejs.org/en/about/previous-releases#release-schedule).
+Node version support is for even numbered releases (22, 24, etc) that are current, active or in LTS maintenance. For more information, [see here](https://nodejs.org/en/about/previous-releases#release-schedule).
 
 ### Python (TBD)
 

--- a/knife
+++ b/knife
@@ -170,7 +170,7 @@ function cmd_update_node_archives () {
 	fi
 
     versions=()
-    for major in 20 22 24; do
+    for major in 22 24; do
         latest_version=$(curl -sSL https://nodejs.org/dist/index.json | jq -r --arg major "v$major" '
             map(select(.version | startswith($major)))
             | sort_by(.date) | reverse | .[0].version

--- a/nodejs/config.bzl
+++ b/nodejs/config.bzl
@@ -1,9 +1,8 @@
 NODEJS_DISTROS = ["debian13"]
 NODEJS_ARCHITECTURES = {
     "debian13": {
-        "20": ["amd64", "arm64", "arm", "s390x", "ppc64le"],
         "22": ["amd64", "arm64", "arm", "s390x", "ppc64le"],
         "24": ["amd64", "arm64", "s390x", "ppc64le"],
     },
 }
-NODEJS_MAJOR_VERSIONS = ["20", "22", "24"]
+NODEJS_MAJOR_VERSIONS = ["22", "24"]

--- a/nodejs/testdata/nodejs20.yaml
+++ b/nodejs/testdata/nodejs20.yaml
@@ -1,6 +1,0 @@
-schemaVersion: "2.0.0"
-commandTests:
-  - name: nodejs
-    command: "/nodejs/bin/node"
-    args: ["--version"]
-    expectedOutput: ["v20.20.2"]

--- a/private/extensions/node.bzl
+++ b/private/extensions/node.bzl
@@ -100,56 +100,6 @@ def _node_impl(module_ctx):
     # Follow Node's maintenance schedule and support all LTS versions that are not end of life
 
     node_archive(
-        name = "nodejs20_amd64",
-        sha256 = "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b",
-        strip_prefix = "node-v20.20.2-linux-x64/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-x64.tar.gz"],
-        version = "20.20.2",
-        architecture = "amd64",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs20_arm64",
-        sha256 = "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d",
-        strip_prefix = "node-v20.20.2-linux-arm64/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-arm64.tar.gz"],
-        version = "20.20.2",
-        architecture = "arm64",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs20_arm",
-        sha256 = "8e15f121e721c9354132053188d4c1a18ea9e345c019ee440fb256e3dda7df15",
-        strip_prefix = "node-v20.20.2-linux-armv7l/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-armv7l.tar.gz"],
-        version = "20.20.2",
-        architecture = "arm",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs20_ppc64le",
-        sha256 = "5f2fd0e0cd67aeac0db800b334151cae6ea70ea337487b26f79ac90e3fe126e1",
-        strip_prefix = "node-v20.20.2-linux-ppc64le/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-ppc64le.tar.gz"],
-        version = "20.20.2",
-        architecture = "ppc64le",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs20_s390x",
-        sha256 = "ee1ca1193e75a6d31b6007c575deca11b116e84a6bda136ae0e0dbe19399889c",
-        strip_prefix = "node-v20.20.2-linux-s390x/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-s390x.tar.gz"],
-        version = "20.20.2",
-        architecture = "s390x",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
         name = "nodejs22_amd64",
         sha256 = "978978a635eef872fa68beae09f0aad0bbbae6757e444da80b570964a97e62a3",
         strip_prefix = "node-v22.22.2-linux-x64/",
@@ -241,11 +191,6 @@ def _node_impl(module_ctx):
 
     return module_ctx.extension_metadata(
         root_module_direct_deps = [
-            "nodejs20_amd64",
-            "nodejs20_arm64",
-            "nodejs20_arm",
-            "nodejs20_ppc64le",
-            "nodejs20_s390x",
             "nodejs22_amd64",
             "nodejs22_arm64",
             "nodejs22_arm",

--- a/private/extensions/node.bzl
+++ b/private/extensions/node.bzl
@@ -100,56 +100,6 @@ def _node_impl(module_ctx):
     # Follow Node's maintainence schedule and support all LTS versions that are not end of life
 
     node_archive(
-        name = "nodejs20_amd64",
-        sha256 = "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b",
-        strip_prefix = "node-v20.20.2-linux-x64/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-x64.tar.gz"],
-        version = "20.20.2",
-        architecture = "amd64",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs20_arm64",
-        sha256 = "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d",
-        strip_prefix = "node-v20.20.2-linux-arm64/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-arm64.tar.gz"],
-        version = "20.20.2",
-        architecture = "arm64",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs20_arm",
-        sha256 = "8e15f121e721c9354132053188d4c1a18ea9e345c019ee440fb256e3dda7df15",
-        strip_prefix = "node-v20.20.2-linux-armv7l/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-armv7l.tar.gz"],
-        version = "20.20.2",
-        architecture = "arm",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs20_ppc64le",
-        sha256 = "5f2fd0e0cd67aeac0db800b334151cae6ea70ea337487b26f79ac90e3fe126e1",
-        strip_prefix = "node-v20.20.2-linux-ppc64le/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-ppc64le.tar.gz"],
-        version = "20.20.2",
-        architecture = "ppc64le",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
-        name = "nodejs20_s390x",
-        sha256 = "ee1ca1193e75a6d31b6007c575deca11b116e84a6bda136ae0e0dbe19399889c",
-        strip_prefix = "node-v20.20.2-linux-s390x/",
-        urls = ["https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-s390x.tar.gz"],
-        version = "20.20.2",
-        architecture = "s390x",
-        control = "//nodejs:control",
-    )
-
-    node_archive(
         name = "nodejs22_amd64",
         sha256 = "978978a635eef872fa68beae09f0aad0bbbae6757e444da80b570964a97e62a3",
         strip_prefix = "node-v22.22.2-linux-x64/",
@@ -241,11 +191,6 @@ def _node_impl(module_ctx):
 
     return module_ctx.extension_metadata(
         root_module_direct_deps = [
-            "nodejs20_amd64",
-            "nodejs20_arm64",
-            "nodejs20_arm",
-            "nodejs20_ppc64le",
-            "nodejs20_s390x",
             "nodejs22_amd64",
             "nodejs22_arm64",
             "nodejs22_arm",


### PR DESCRIPTION
~Nodejs 20 reaches EOL 30th of April 2026, so this PR just prepares the removal of it and shouldn't be merged until after 30th of April.~

Nodejs 20 has reached EOL.