### PR TITLE
Add k8gb to Who uses Distroless

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ BUILD       Dockerfile  hello.py
 - [Tekton](https://tekton.dev)
 - [Teleport](https://goteleport.com)
 - [BloodHound](https://github.com/SpecterOps/BloodHound) by [SpecterOps](https://specterops.io/)
+- [K8gb](https://www.k8gb.io/) - Kubernetes Global Load Balancer
 
 If your project uses Distroless, send a PR to add your project here!
 


### PR DESCRIPTION
**K8GB** is a Kubernetes based global load balancer that uses Distroless base images for its container images. Adding to the list of adopters.

Ref: https://github.com/k8gb-io/k8gb/issues/1011