### PR TITLE
ci: restrict self-hosted runner jobs to non-fork PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,8 @@ jobs:
 
   ci-build-test:
     name: CI build and unit test
+    # Restrict to non-fork PRs: self-hosted runner has access to GCP credentials.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: distroless-ci-large-ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
@@ -51,6 +53,7 @@ jobs:
 
   ci-images:
     name: CI image tests
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: distroless-ci-large-ubuntu-22.04
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/image-check.yaml
+++ b/.github/workflows/image-check.yaml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   diff:
+    # Restrict to non-fork PRs: self-hosted runner has GCP credentials; fork
+    # code (BUILD files, diff.bash) would execute on it without this guard.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: distroless-ci-large-ubuntu-22.04
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Jobs `ci-build-test` and `ci-images` in `ci.yaml`, and `diff` in `image-check.yaml`, run on the `distroless-ci-large-ubuntu-22.04` self-hosted runner. These jobs check out the PR author's code and execute it (Bazel BUILD rules, `private/tools/diff/diff.bash`) on the runner without any fork restriction.

An attacker who opens a PR from a fork can modify `BUILD` files to include a malicious `genrule`, or modify `private/tools/diff/diff.bash`, and have that code execute on the self-hosted runner. Self-hosted GCP runners have GCE service account credentials accessible via the metadata server (`http://metadata.google.internal/`).

**Affected jobs (no fork guard at job level):**
- `ci.yaml` → `ci-build-test` (runs fork's Bazel targets + `bazel test //...`)
- `ci.yaml` → `ci-images` (runs fork's Bazel image tests)
- `image-check.yaml` → `diff` (runs `bazel build //:sign_and_push` + `./private/tools/diff/diff.bash` from fork)

Note: `image-check.yaml` has fork checks on comment-posting steps, but not on the build/execution steps where the actual risk exists.

## Fix

Add `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository` to each affected job:
- `push` and `workflow_dispatch` events are unaffected
- Fork PRs skip the self-hosted runner jobs entirely

## Test plan

- [ ] Verify CI passes on a same-repo PR after this change
- [ ] Verify that fork PRs skip `ci-build-test`, `ci-images`, and `diff` jobs (expected: jobs show as skipped in workflow run)