### PR TITLE
validate_usr_symlinks: match `type=link` as a whole mtree field

### DIFF
--- a/private/util/validate_usr_symlinks.awk
+++ b/private/util/validate_usr_symlinks.awk
@@ -18,9 +18,15 @@ BEGIN {
     sub(/^(\.\/|\/)+/, "", path)
 
     if (path in expected) {
-        if ($0 !~ /type=link/) {
+        # Match `type=link` only as a whole mtree field — bounded by whitespace
+        # on the left and whitespace or end-of-line on the right. A naive
+        # substring match was tricked by other mtree field values that happened
+        # to contain the literal string "type=link" (for example a uname,
+        # gname, or flags value), silently skipping the symlink check for a
+        # non-symlink entry at /bin, /sbin, /lib, etc.
+        if ($0 !~ /[[:space:]]type=link([[:space:]]|$)/) {
             VIOLATIONS[original_path] = original_path " is not a symlink (must link to " expected[path] ")"
-        } else if (match($0, / link=([^ \t]+)/, dest) && dest[1] != expected[path]) {
+        } else if (match($0, /[[:space:]]link=([^[:space:]]+)/, dest) && dest[1] != expected[path]) {
             VIOLATIONS[original_path] = original_path " symlinks to '" dest[1] "' instead of '" expected[path] "'"
         }
     } else if (path ~ ("^(" prefixes ")/")) {

--- a/private/util/validate_usr_symlinks_test.sh
+++ b/private/util/validate_usr_symlinks_test.sh
@@ -87,4 +87,27 @@ run "/lib/libfoo.so.1 type=file mode=0644 nlink=1 uid=0 gid=0 size=4096" \
 run "./bin/ls type=file mode=0755 nlink=1 uid=0 gid=0 size=12345" \
   && fail "content under ./bin/ should fail" || true
 
+# --- substring-match regression cases ---
+# An earlier version of this check used `$0 !~ /type=link/`, which matched the
+# string "type=link" anywhere on the line, including inside other mtree field
+# values. A non-symlink entry whose uname/gname/flags happened to contain that
+# substring would silently pass. The check is now field-bounded.
+
+run "./bin type=dir uname=type=link gname=root mode=0755 uid=0 gid=0" \
+  && fail "./bin as a dir with uname=type=link should fail (substring bypass)" || true
+
+run "./bin type=dir uname=root gname=type=link mode=0755 uid=0 gid=0" \
+  && fail "./bin as a dir with gname=type=link should fail (substring bypass)" || true
+
+run "./bin type=dir flags=type=link mode=0755 uid=0 gid=0" \
+  && fail "./bin as a dir with flags=type=link should fail (substring bypass)" || true
+
+run "./lib type=dir uname=type=link mode=0755 uid=0 gid=0" \
+  && fail "./lib as a dir with uname=type=link should fail (substring bypass)" || true
+
+# A legitimate symlink that happens to carry extra trailing fields must keep
+# working under the field-bounded check.
+run "./bin type=link mode=0777 nlink=1 uid=0 gid=0 link=usr/bin extra=ignored" \
+  || fail "./bin -> usr/bin with extra trailing field should pass"
+
 echo "All tests passed."


### PR DESCRIPTION
## Summary

The aspect's awk script in `private/util/validate_usr_symlinks.awk` used `$0 !~ /type=link/` to decide whether an entry at `/bin`, `/sbin`, `/lib`, `/lib32`, `/lib64`, or `/libx32` was a symlink. Because the pattern was a plain substring match, any mtree field value elsewhere on the line that happened to contain the literal string `type=link` (e.g. `uname=type=link`, `gname=type=link`, a `flags` value spelled the same way) would satisfy the check, and the aspect would silently accept a non-symlink at that path — breaking the merged-usr invariant that the aspect exists to enforce.

A symmetric issue existed in the ` link=` match used to verify the symlink target, which could in principle be anchored against the trailing characters of a prior field rather than a true field boundary.

This PR anchors both regexes to whitespace boundaries so they operate on whole mtree fields and adds regression tests.

## Reproduction (against the unfixed script)

```
$ printf './bin type=dir uname=type=link gname=root mode=0755 uid=0 gid=0\n' \
    | gawk -v validation_output_file=/dev/null -f private/util/validate_usr_symlinks.awk
$ echo $?
0
```

The script reports no violation even though `./bin` is a directory, not a symlink to `usr/bin`. With this PR:

```
$ ./bazel-bin/private/util/validate_usr_symlinks_test
VIOLATION: ./bin is not a symlink (must link to usr/bin) violates usr-merge convention.
./bin
$ echo $?
1
```

## Risk assessment

For images built from the snapshots in `private/repos/deb/*.lock.json` this is defense-in-depth: Debian-supplied `.debs` do not carry `uname`/`gname`/`flags` values shaped like `type=link`, so the bypass cannot be reached from current sources. The fix matters mainly because the aspect's stated job is to catch merged-usr-violating layers regardless of how they end up in the input tars (locally-built tars, custom packages, future non-Debian sources).

## Test plan

- [x] `private/util/validate_usr_symlinks_test.sh` passes locally (existing cases + 5 new regression cases).
- [x] Each new regression case fails with the pre-PR awk and passes with the post-PR awk.
- [ ] CI green.