### PR TITLE
Add OCI source annotation and custom version annotation to images

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,7 +48,7 @@ use_repo(busybox, "busybox_amd64", "busybox_arm", "busybox_arm64", "busybox_ppc6
 ### NODE ###
 node = use_extension("//private/extensions:node.bzl", "node")
 node.archive()
-use_repo(node, "nodejs22_amd64", "nodejs22_arm", "nodejs22_arm64", "nodejs22_ppc64le", "nodejs22_s390x", "nodejs24_amd64", "nodejs24_arm64", "nodejs24_ppc64le", "nodejs24_s390x", "nodejs26_amd64", "nodejs26_arm64", "nodejs26_ppc64le", "nodejs26_s390x")
+use_repo(node, "node_versions", "nodejs22_amd64", "nodejs22_arm", "nodejs22_arm64", "nodejs22_ppc64le", "nodejs22_s390x", "nodejs24_amd64", "nodejs24_arm64", "nodejs24_ppc64le", "nodejs24_s390x", "nodejs26_amd64", "nodejs26_arm64", "nodejs26_ppc64le", "nodejs26_s390x")
 
 ### DEBIAN ###
 include("//private/repos/deb:deb.MODULE.bazel")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -346,7 +346,7 @@
     },
     "//private/extensions:node.bzl%node": {
       "general": {
-        "bzlTransitiveDigest": "PYEZwHH1aAE8zXcz/NIvvusp8vmjOf4SUyxs2WbI0CE=",
+        "bzlTransitiveDigest": "sKANl0sF6tWqzb6m37MKvdmqUNf4PEFToBNwYlUaM2c=",
         "usagesDigest": "oo4hnOxowfXXa21Wd8roJmpRdyG7Fy97FBO9vJoyK/M=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -533,10 +533,32 @@
               "architecture": "s390x",
               "control": "@@//nodejs:control"
             }
+          },
+          "node_versions": {
+            "bzlFile": "@@//private/extensions:node.bzl",
+            "ruleClassName": "node_versions_repo",
+            "attributes": {
+              "versions": {
+                "22_amd64": "22.23.1",
+                "22_arm64": "22.23.1",
+                "22_arm": "22.23.1",
+                "22_ppc64le": "22.23.1",
+                "22_s390x": "22.23.1",
+                "24_amd64": "24.18.0",
+                "24_arm64": "24.18.0",
+                "24_ppc64le": "24.18.0",
+                "24_s390x": "24.18.0",
+                "26_amd64": "26.4.0",
+                "26_arm64": "26.4.0",
+                "26_ppc64le": "26.4.0",
+                "26_s390x": "26.4.0"
+              }
+            }
           }
         },
         "moduleExtensionMetadata": {
           "explicitRootModuleDirectDeps": [
+            "node_versions",
             "nodejs22_amd64",
             "nodejs22_arm64",
             "nodejs22_arm",

--- a/base/base.bzl
+++ b/base/base.bzl
@@ -2,7 +2,7 @@
 
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
-load("//common:variables.bzl", "DEBUG_MODE", "USERS")
+load("//common:variables.bzl", "DEBUG_MODE", "OS_RELEASE", "USERS")
 load("//private/util:deb.bzl", "deb")
 
 def base_nossl_image_index(distro, architectures):
@@ -59,6 +59,7 @@ def base_nossl_image(distro, arch, packages):
                 deb.package(arch, distro, pkg)
                 for pkg in packages
             ],
+            annotations = {"org.opencontainers.image.source": OS_RELEASE["HOME_URL"]},
         )
         for user in USERS
         for mode in DEBUG_MODE
@@ -100,6 +101,7 @@ def base_image(distro, arch, packages):
                 deb.package(arch, distro, pkg)
                 for pkg in packages
             ],
+            annotations = {"org.opencontainers.image.source": OS_RELEASE["HOME_URL"]},
         )
         for user in USERS
         for mode in DEBUG_MODE

--- a/cc/cc.bzl
+++ b/cc/cc.bzl
@@ -1,5 +1,5 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
-load("//common:variables.bzl", "DEBUG_MODE", "USERS")
+load("//common:variables.bzl", "DEBUG_MODE", "OS_RELEASE", "USERS")
 load("//private/util:deb.bzl", "deb")
 
 def cc_image_index(distro, architectures):
@@ -36,6 +36,7 @@ def cc_image(distro, arch, packages):
                 deb.package(arch, distro, pkg)
                 for pkg in packages
             ],
+            annotations = {"org.opencontainers.image.source": OS_RELEASE["HOME_URL"]},
         )
         for mode in DEBUG_MODE
         for user in USERS

--- a/java/java.bzl
+++ b/java/java.bzl
@@ -2,7 +2,7 @@
 
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
-load("//common:variables.bzl", "DEBUG_MODE", "USERS")
+load("//common:variables.bzl", "DEBUG_MODE", "OS_RELEASE", "USERS")
 load("//java:jre_ver.bzl", "jre_ver")
 load("//private/oci:defs.bzl", oci_java_image = "java_image")
 load("//private/util:deb.bzl", "deb")
@@ -142,6 +142,12 @@ def java_image(distro, java_version, arch):
 
     # standard image builds
     for user in USERS:
+        _jre_version = jre_ver(deb.version(
+            arch,
+            distro,
+            "temurin-" + java_version + "-jre",
+            "adoptium",
+        ))
         oci_image(
             name = "java" + java_version + "_" + user + "_" + arch + "_" + distro,
             base = ":java_base_" + user + "_" + arch + "_" + distro,
@@ -151,13 +157,12 @@ def java_image(distro, java_version, arch):
                 "/usr/bin/java",
                 "-jar",
             ],
+            annotations = {
+                "org.opencontainers.image.source": OS_RELEASE["HOME_URL"],
+                "com.google.distroless.java.version": _jre_version,
+            },
             env = {
-                "JAVA_VERSION": jre_ver(deb.version(
-                    arch,
-                    distro,
-                    "temurin-" + java_version + "-jre",
-                    "adoptium",
-                )),
+                "JAVA_VERSION": _jre_version,
             },
             tars = [
                 # we use system certs, but we might want to pull this out of the distro
@@ -168,6 +173,12 @@ def java_image(distro, java_version, arch):
 
     # debug image builds
     for user in USERS:
+        _jdk_version = jre_ver(deb.version(
+            arch,
+            distro,
+            "temurin-" + java_version + "-jdk",
+            "adoptium",
+        ))
         oci_image(
             name = "java" + java_version + "_debug_" + user + "_" + arch + "_" + distro,
             base = ":java_base_debug_" + user + "_" + arch + "_" + distro,
@@ -177,13 +188,12 @@ def java_image(distro, java_version, arch):
                 "/usr/bin/java",
                 "-jar",
             ],
+            annotations = {
+                "org.opencontainers.image.source": OS_RELEASE["HOME_URL"],
+                "com.google.distroless.java.version": _jdk_version,
+            },
             env = {
-                "JAVA_VERSION": jre_ver(deb.version(
-                    arch,
-                    distro,
-                    "temurin-" + java_version + "-jdk",
-                    "adoptium",
-                )),
+                "JAVA_VERSION": _jdk_version,
             },
             tars = [
                 # we use system certs, but we might want to pull this out of the distro

--- a/knife.d/update_node_archives.js
+++ b/knife.d/update_node_archives.js
@@ -152,6 +152,24 @@ node_archive = repository_rule(
     },
 )
 
+_NODE_VERSIONS_TMPL = """\\
+"node versions"
+
+# AUTO GENERATED. DO NOT EDIT.
+NODEJS_VERSIONS = {versions}
+"""
+
+def _node_versions_repo_impl(rctx):
+    rctx.file("versions.bzl", _NODE_VERSIONS_TMPL.format(versions = str(rctx.attr.versions)))
+    rctx.file("BUILD.bazel", 'exports_files(["versions.bzl"])')
+
+node_versions_repo = repository_rule(
+    implementation = _node_versions_repo_impl,
+    attrs = {
+        "versions": attr.string_dict(),
+    },
+)
+
 def _node_impl(module_ctx):
     mod = module_ctx.modules[0]
 
@@ -202,8 +220,28 @@ commandTests:
   }
   nodeArchives += `
 
+    node_versions_repo(
+        name = "node_versions",
+        versions = {`;
+
+  for (const nodeVersion of versions) {
+    const major = parseInt(nodeVersion.split(".")[0]);
+    for (const arch of architectures) {
+      if (major > 22 && arch === "arm") {
+        continue;
+      }
+      nodeArchives += `
+            "${major}_${arch}": "${nodeVersion}",`;
+    }
+  }
+
+  nodeArchives += `
+        },
+    )
+
     return module_ctx.extension_metadata(
-        root_module_direct_deps = [`;
+        root_module_direct_deps = [
+            "node_versions",`;
 
   for (const nodeVersion of versions) {
     const major = parseInt(nodeVersion.split(".")[0]);

--- a/nodejs/nodejs.bzl
+++ b/nodejs/nodejs.bzl
@@ -1,8 +1,9 @@
 "nodejs image definitions"
 
 load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@node_versions//:versions.bzl", "NODEJS_VERSIONS")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
-load("//common:variables.bzl", "DEBUG_MODE", "USERS")
+load("//common:variables.bzl", "DEBUG_MODE", "OS_RELEASE", "USERS")
 load("//private/util:deb.bzl", "deb")
 load("//private/util:tar.bzl", "tar")
 
@@ -45,6 +46,14 @@ def nodejs_image(distro, major_version, arch, packages):
         packages: any deb packages to add to the image
     """
 
+    _version_key = major_version + "_" + arch
+    if _version_key not in NODEJS_VERSIONS:
+        fail("No version found for Node.js major version/arch: " + _version_key)
+    _annotations = {
+        "org.opencontainers.image.source": OS_RELEASE["HOME_URL"],
+        "com.google.distroless.nodejs.version": NODEJS_VERSIONS[_version_key],
+    }
+
     for mode in DEBUG_MODE:
         for user in USERS:
             oci_image(
@@ -57,6 +66,7 @@ def nodejs_image(distro, major_version, arch, packages):
                 ] + [
                     "@nodejs" + major_version + "_" + arch,
                 ],
+                annotations = _annotations,
             )
 
     _check_certificates_tar()

--- a/private/extensions/node.bzl
+++ b/private/extensions/node.bzl
@@ -88,6 +88,24 @@ node_archive = repository_rule(
     },
 )
 
+_NODE_VERSIONS_TMPL = """\
+"node versions"
+
+# AUTO GENERATED. DO NOT EDIT.
+NODEJS_VERSIONS = {versions}
+"""
+
+def _node_versions_repo_impl(rctx):
+    rctx.file("versions.bzl", _NODE_VERSIONS_TMPL.format(versions = str(rctx.attr.versions)))
+    rctx.file("BUILD.bazel", 'exports_files(["versions.bzl"])')
+
+node_versions_repo = repository_rule(
+    implementation = _node_versions_repo_impl,
+    attrs = {
+        "versions": attr.string_dict(),
+    },
+)
+
 def _node_impl(module_ctx):
     mod = module_ctx.modules[0]
 
@@ -229,8 +247,28 @@ def _node_impl(module_ctx):
         control = "//nodejs:control",
     )
 
+    node_versions_repo(
+        name = "node_versions",
+        versions = {
+            "22_amd64": "22.23.1",
+            "22_arm64": "22.23.1",
+            "22_arm": "22.23.1",
+            "22_ppc64le": "22.23.1",
+            "22_s390x": "22.23.1",
+            "24_amd64": "24.18.0",
+            "24_arm64": "24.18.0",
+            "24_ppc64le": "24.18.0",
+            "24_s390x": "24.18.0",
+            "26_amd64": "26.4.0",
+            "26_arm64": "26.4.0",
+            "26_ppc64le": "26.4.0",
+            "26_s390x": "26.4.0",
+        },
+    )
+
     return module_ctx.extension_metadata(
         root_module_direct_deps = [
+            "node_versions",
             "nodejs22_amd64",
             "nodejs22_arm64",
             "nodejs22_arm",

--- a/python3/python.bzl
+++ b/python3/python.bzl
@@ -2,7 +2,7 @@
 
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
-load("//common:variables.bzl", "DEBUG_MODE", "USERS")
+load("//common:variables.bzl", "DEBUG_MODE", "OS_RELEASE", "USERS")
 load("//private/util:deb.bzl", "deb")
 load("//private/util:tar.bzl", "tar")
 
@@ -65,6 +65,7 @@ def python3_image(distro, arch, packages):
                     deb.package(arch, distro, pkg, "python")
                     for pkg in packages
                 ] + [":python_aliases_%s" % distro] + ([":ldconfig_cache_" + arch] if distro == "debian13" else []),
+                annotations = {"org.opencontainers.image.source": OS_RELEASE["HOME_URL"]},
             )
 
     for user in USERS:

--- a/static/static.bzl
+++ b/static/static.bzl
@@ -4,7 +4,7 @@ load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_go//go:def.bzl", "go_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("//:distro.bzl", "VARIANTS")
-load("//common:variables.bzl", "DEBUG_MODE", "NONROOT")
+load("//common:variables.bzl", "DEBUG_MODE", "NONROOT", "OS_RELEASE")
 load("//private/util:deb.bzl", "deb")
 load("//private/util:tar.bzl", "tar")
 
@@ -65,6 +65,7 @@ def static_image(distro, arch, packages):
             os = "linux",
             architecture = arch,
             variant = VARIANTS.get(arch),
+            annotations = {"org.opencontainers.image.source": OS_RELEASE["HOME_URL"]},
         )
 
         # A static debug image with busybox available.
@@ -74,6 +75,7 @@ def static_image(distro, arch, packages):
             entrypoint = ["/busybox/sh"],
             env = {"PATH": "$PATH:/busybox"},
             tars = ["//experimental/busybox:busybox_" + arch],
+            annotations = {"org.opencontainers.image.source": OS_RELEASE["HOME_URL"]},
         )
 
     ##########################################################################################


### PR DESCRIPTION
Adds OCI image annotations to all distroless image types, addressing the version pinning request in #686.

Annotations added:

* `org.opencontainers.image.source` - set to the repository URL (from OS_RELEASE["HOME_URL"] in variables.bzl) on all image types: base, cc, static, python3, nodejs, and java
* `com.google.distroless.nodejs.version` - the specific Node.js archive version (e.g. 24.18.0), per architecture
* `com.google.distroless.java.version` - the specific Temurin JRE/JDK version installed

The `org.opencontainers.image.source` annotation is the most essential annotation to add, per

https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/

The Java and NodeJS images are the only images where it makes sense to add a separate version annotation, and for these I think a custom namespace (`com.google.distroless`) is needed.

More annotations can be added later as needed.

Implementation notes for NodeJS versioning:

Rather than adding a static NODEJS_VERSIONS dict to config.bzl, a new node_versions_repo repository rule is generated by the existing node module extension in node.bzl. This creates an @node_versions//:versions.bzl file that nodejs.bzl loads at analysis time - the same pattern used for Debian package versions. The update_node_archives.js script is updated to regenerate the node_versions_repo() call alongside the existing node_archive() calls, so there is no version data to keep in sync manually.

Closes #686