### PR TITLE
Use distroless-bot token when creating/update an update PR

### DIFF
--- a/.github/workflows/update-deb-package-non-snapshots.yml
+++ b/.github/workflows/update-deb-package-non-snapshots.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.ACTIONS_TOKEN }}
 
       - name: Update non-snapshots
         run: ./knife update-non-snapshots

--- a/.github/workflows/update-deb-package-snapshots.yml
+++ b/.github/workflows/update-deb-package-snapshots.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.ACTIONS_TOKEN }}
       - uses: actions/setup-go@v7
         with:
           go-version: "1.25"

--- a/.github/workflows/update-node-archives.yml
+++ b/.github/workflows/update-node-archives.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.ACTIONS_TOKEN }}
       - uses: actions/setup-node@v7
 
       - name: Update node archives


### PR DESCRIPTION
We were using the default token before which cause CI to pause for updates. Use the distroless-bot token for new and updated pushes.