### PR TITLE
Use bazel bsdtar instead of system tools

### DIFF
--- a/private/pkg/debian_spdx.bzl
+++ b/private/pkg/debian_spdx.bzl
@@ -1,28 +1,35 @@
+load("@aspect_bazel_lib//lib:tar.bzl", "tar_lib")
+
 SPDX_CMD = """\
+readonly bsdtar="$1"
+readonly control="$2"
+readonly data="$3"
+readonly package_name="$4"
+readonly generator="$5"
+shift 5
+
 tmp="$(mktemp -d)"
 
-tar -xf "$1" -C "$tmp" "./control" || tar -xf "$1" -C "$tmp" "control"
+"$bsdtar" -xf "$control" -C "$tmp" "./control" 2>/dev/null || "$bsdtar" -xf "$control" -C "$tmp" "control"
 
-if  tar -xf "$2" -C "$tmp" "usr/share/doc/$3/copyright" >/dev/null 2>&1; then
-    COPYRIGHT="$tmp/usr/share/doc/$3/copyright"
+COPYRIGHT=""
+if "$bsdtar" -xf "$data" -C "$tmp" "usr/share/doc/$package_name/copyright" 2>/dev/null || "$bsdtar" -xf "$data" -C "$tmp" "./usr/share/doc/$package_name/copyright" 2>/dev/null; then
+    COPYRIGHT="$tmp/usr/share/doc/$package_name/copyright"
 fi
 
-if  tar -xf "$2" -C "$tmp" "./usr/share/doc/$3/copyright" >/dev/null 2>&1; then
-    COPYRIGHT="$tmp/usr/share/doc/$3/copyright"
-fi
-shift
-shift
-shift
-{generator} --control="$tmp/control" --copyright=$COPYRIGHT $@
+"$generator" --control="$tmp/control" --copyright="$COPYRIGHT" "$@"
 """
 
 def _impl(ctx):
+    bsdtar = ctx.toolchains[tar_lib.toolchain_type]
     output = ctx.actions.declare_file("%s.spdx.json" % ctx.label.name)
 
     args = ctx.actions.args()
+    args.add(bsdtar.tarinfo.binary.path)
     args.add(ctx.file.control.path)
     args.add(ctx.file.data.path)
     args.add(ctx.attr.package_name)
+    args.add(ctx.executable._generator.path)
     args.add(ctx.attr.spdx_id, format = "--id=%s")
     args.add(output.path, format = "--output=%s")
     args.add(ctx.label, format = "--generates=%s")
@@ -34,8 +41,8 @@ def _impl(ctx):
     ctx.actions.run_shell(
         inputs = [ctx.file.control, ctx.file.data],
         outputs = [output],
-        command = SPDX_CMD.format(generator = ctx.file._generator.path),
-        tools = [ctx.executable._generator],
+        command = SPDX_CMD,
+        tools = [ctx.executable._generator, bsdtar.default.files],
         arguments = [args],
     )
 
@@ -54,4 +61,5 @@ debian_spdx = rule(
         "sha256": attr.string(mandatory = True),
         "_generator": attr.label(default = ":debian_spdx", executable = True, allow_single_file = True, cfg = "exec"),
     },
+    toolchains = [tar_lib.toolchain_type],
 )


### PR DESCRIPTION
Turns out our cloud build doesn't like the compression that the adoptium control files were using. So use the toolchain for tar instead of the system tools.