### PR TITLE
fix: update broken registry.bazel.build/docs URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Any other tags are considered deprecated and are no longer updated
 
 #### Debian 13
 
-Debian 13 distroless images use the debian [UsrMerge](https://wiki.debian.org/UsrMerge) scheme. If you use `rules_distroless` to add packages to an image, set `mergedusr = True` in [`apt.install`](https://registry.bazel.build/docs/rules_distroless#apt_install).
+Debian 13 distroless images use the debian [UsrMerge](https://wiki.debian.org/UsrMerge) scheme. If you use `rules_distroless` to add packages to an image, set `mergedusr = True` in [`apt.install`](https://registry.bazel.build/modules/rules_distroless/latest/docs/apt/extensions.bzl/apt).
 
 | Image                                 | Tags                                  | Architecture Suffixes                      |
 | ------------------------------------- | ------------------------------------- | ------------------------------------------ |


### PR DESCRIPTION
## Summary

The `registry.bazel.build/docs/<name>` URL pattern returns 404 and is no longer valid.

The correct URL format is now `registry.bazel.build/modules/<name>/latest/docs`.

This was identified across multiple Bazel rule repositories — see https://github.com/hermeticbuild/rules_rs/pull/235 for the original fix.

## Changes

- Replaced broken `/docs/rules_distroless` URL with `/modules/rules_distroless/latest/docs`
- Replaced symbol anchor with explicit path:
  - `#apt_install` → `/apt/extensions.bzl/apt`